### PR TITLE
add Set Heat Source service and Heat Pump / Furnace Status sensors

### DIFF
--- a/custom_components/infinitude_beyond/infinitude/const.py
+++ b/custom_components/infinitude_beyond/infinitude/const.py
@@ -83,3 +83,10 @@ class HumidifierState(Enum):
 
     ON = "on"
     OFF = "off"
+
+class HeatSource(Enum):
+    """Heat Source currently used """
+
+    SYSTEM = "System"
+    GAS = "Gas"
+    HEATPUMP = "Heat Pump"

--- a/custom_components/infinitude_beyond/sensor.py
+++ b/custom_components/infinitude_beyond/sensor.py
@@ -94,6 +94,26 @@ SYSTEM_SENSORS: tuple[InfinitudeSensorDescription, ...] = (
         value_fn=lambda entity: entity.system.airflow_cfm,
     ),
     InfinitudeSensorDescription(
+        key="furnace_status",
+        name="Furnace Status",
+        value_fn=lambda entity: entity.system.furnace_status,
+    ),
+    InfinitudeSensorDescription(
+        key="heatpump_status",
+        name="Heatpump Status",
+        value_fn=lambda entity: entity.system.heatpump_status,
+    ),
+    InfinitudeSensorDescription(
+        key="heatpump_mode",
+        name="Heatpump Mode",
+        value_fn=lambda entity: entity.system.heatpump_mode,
+    ),
+    InfinitudeSensorDescription(
+        key="heat_source",
+        name="Heat Source",
+        value_fn=lambda entity: entity.system.heat_source,
+    ),
+    InfinitudeSensorDescription(
         key="idu_modulation",
         name="IDU modulation",
         native_unit_of_measurement="%",

--- a/custom_components/infinitude_beyond/services.yaml
+++ b/custom_components/infinitude_beyond/services.yaml
@@ -4,7 +4,7 @@ set_hold_mode:
   description: Sets the Hold Mode and Activity for an Infinitude zone
   target:
     entity:
-      integration: infinitude
+      integration: infinitude_beyond   
       domain: climate
   fields:
     mode:
@@ -32,3 +32,20 @@ set_hold_mode:
             - "manual"
       description: "Name of the activity profile to hold with.  If not provided, defaults to the current activity."
       example: "'home', 'away', 'sleep', 'wake', 'manual'"
+
+set_heat_source:
+  description: Sets the Heat Source of the Infinitude equipment 
+  target:
+    entity:
+      integration: infinitude_beyond          
+      domain: climate
+  fields:
+    heatsource:
+      selector:
+        select:
+          options:
+            - "System"
+            - "Gas"
+            - "Heat Pump"
+      description: "Select the heat source of the equipment. 'System', 'Gas' or 'Heat Pump'"
+      example: "'System', 'Gas', 'Heat Pump'"


### PR DESCRIPTION
Hello @MizterB 
I have modified your integration to add extra functionality for dual fuel systems. Use case: switch the source based on your time of use cost of gas and electricity. It works on my system. Please consider merging it 

- Added a service to change the heat source between System, Gas, Heat Pump for dual fuel systems
- Added few sensors to display the HP and Gas furnace status 
- Bug fix: fixed entity to belong to infinitude_beyond
- Bug fix: service would accept until = Null , for indefinite hold 