### PR TITLE
Prevent infinite loop when determining activity_next

### DIFF
--- a/custom_components/infinitude_beyond/infinitude/api.py
+++ b/custom_components/infinitude_beyond/infinitude/api.py
@@ -527,7 +527,7 @@ class InfinitudeZone:
         activity_next = None
         activity_next_start = None
         try:
-            while activity_next is None:
+            for i in range(7):
                 day_name = dt.strftime("%A")
                 program = next(
                     day

--- a/custom_components/infinitude_beyond/infinitude/api.py
+++ b/custom_components/infinitude_beyond/infinitude/api.py
@@ -739,7 +739,7 @@ class InfinitudeZone:
         """Next scheduled activity."""
         activity = next((a for a in Activity if a.value == self._activity_next), None)
         if activity is None:
-            _LOGGER.warning("'%s' is an unknown Next Activity", self._activity_next)
+            _LOGGER.debug("'%s' is an unknown Next Activity", self._activity_next)
         return activity
 
     @property


### PR DESCRIPTION
I run into an issue while using this integration in which my HA system became unresponsive while the `phyton3` main process consumed 100% of CPU. After digging into the problem I found out this problem is caused when there's no active schedule.

![image](https://github.com/user-attachments/assets/5501086d-406d-4a9c-85f2-33e19f609bfe)

The culprit here is the `_update_activities` method, which fails to detect this scenario and enters an infinite loop.

The method will go day by day trying to find the next available schedule but it fails to give up when it exhaust a full week (hence the `range(7)`, there's no point in continuing once we loop back to the same week day we started). Once `activity_next` is, it `break` out of the loop, therefore no other changes are necessary from what I can tell.

This PR takes care of this and also removes the warning (similar to https://github.com/MizterB/homeassistant-infinitude-beyond/commit/33c8e8fd5403af71031a1b0eed583eaff1ccb3e8). I'm new to this integration so there might be side effects, but at first glance I couldn't spot any.