### PR TITLE
add back ODU Modulation

### DIFF
--- a/custom_components/infinitude_beyond/infinitude/api.py
+++ b/custom_components/infinitude_beyond/infinitude/api.py
@@ -481,6 +481,25 @@ class InfinitudeSystem:
         return None
 
     @property
+    def odu_modulation(self) -> int | None:
+        """Outdoor unit compressor modulation percentage.
+
+        Only get this if the ODU type is 'proteus' or 'gs3ngipac'
+        """
+        odu = self._status.get("odu")
+        if not odu:
+            return None
+        if odu.get("type") in ["proteus", "gs3ngipac"]:
+            odu_opstat = odu.get("opstat")
+            if odu_opstat.isnumeric():
+                return int(odu_opstat)
+            if odu_opstat == "dehumidify": # return 1 for dehumidify
+                return 1
+            if odu_opstat == "off": # return 0 for off
+                return 0
+        return None
+
+    @property
     def energy(self) -> dict | None:
         """Energy data."""
         if isinstance(self._energy, dict) and self._energy != {}:

--- a/custom_components/infinitude_beyond/infinitude/api.py
+++ b/custom_components/infinitude_beyond/infinitude/api.py
@@ -491,12 +491,12 @@ class InfinitudeSystem:
             return None
         if odu.get("type") in ["proteus", "gs3ngipac"]:
             odu_opstat = odu.get("opstat")
+            if odu_opstat.isnumeric():
+                return int(odu_opstat)
             if odu_opstat == "dehumidify": # return 1 for dehumidify
                 return 1
             if odu_opstat == "off": # return 0 for off
                 return 0
-            if odu_opstat[-1].isnumeric():
-                return int(odu_opstat[-1])
         return None
 
     @property

--- a/custom_components/infinitude_beyond/infinitude/api.py
+++ b/custom_components/infinitude_beyond/infinitude/api.py
@@ -491,12 +491,12 @@ class InfinitudeSystem:
             return None
         if odu.get("type") in ["proteus", "gs3ngipac"]:
             odu_opstat = odu.get("opstat")
-            if odu_opstat.isnumeric():
-                return int(odu_opstat)
             if odu_opstat == "dehumidify": # return 1 for dehumidify
                 return 1
             if odu_opstat == "off": # return 0 for off
                 return 0
+            if odu_opstat[-1].isnumeric():
+                return int(odu_opstat[-1])
         return None
 
     @property

--- a/custom_components/infinitude_beyond/sensor.py
+++ b/custom_components/infinitude_beyond/sensor.py
@@ -99,6 +99,12 @@ SYSTEM_SENSORS: tuple[InfinitudeSensorDescription, ...] = (
         native_unit_of_measurement="%",
         value_fn=lambda entity: entity.system.idu_modulation,
     ),
+    InfinitudeSensorDescription(
+        key="odu_modulation",
+        name="ODU modulation",
+        native_unit_of_measurement="%",
+        value_fn=lambda entity: entity.system.odu_modulation,
+    ),
 )
 
 ZONE_SENSORS: tuple[InfinitudeSensorDescription, ...] = (


### PR DESCRIPTION
I had a PR against the old infinitude module to add ODU Modulation support. This was apparently closed, and it mentions IDU support is in this new version - however - there's still no ODU support.

See old issue here:
https://github.com/MizterB/homeassistant-infinitude/pull/57

I raised a new PR to add ODU support that should work with both heat pumps and variable speed compressors. 

There was another PR here for this which added this support hard-coded for heatpumps:
https://github.com/MizterB/homeassistant-infinitude-beyond/pull/34

I tried to keep things more generic in this PR to avoid needing separate sensors for "heatpump" vs "variable compressor", by  presenting "odu_modulation" as the sensor instead