### PR TITLE
Fix preset mode selection and handle after-midnight schedule wrap

### DIFF
--- a/custom_components/infinitude_beyond/climate.py
+++ b/custom_components/infinitude_beyond/climate.py
@@ -289,15 +289,19 @@ class InfinitudeClimate(InfinitudeEntity, ClimateEntity):
     @property
     def preset_mode(self):
         """Return current preset mode."""
-        # If hold is off, preset is the currently scheduled activity
+        # If hold is off, preset should reflect the effective current activity when available.
+        # This avoids showing "Scheduled activity" (graph) or an out-of-date scheduled activity
+        # when Infinitude reports a different currentActivity.
         if self.zone.hold_mode == InfHoldMode.OFF:
-            if self.zone.activity_scheduled == InfActivity.HOME:
+            activity = self.zone.activity_current or self.zone.activity_scheduled
+
+            if activity == InfActivity.HOME:
                 return PRESET_HOME
-            elif self.zone.activity_scheduled == InfActivity.AWAY:
+            elif activity == InfActivity.AWAY:
                 return PRESET_AWAY
-            elif self.zone.activity_scheduled == InfActivity.SLEEP:
+            elif activity == InfActivity.SLEEP:
                 return PRESET_SLEEP
-            elif self.zone.activity_scheduled == InfActivity.WAKE:
+            elif activity == InfActivity.WAKE:
                 return PRESET_WAKE
             else:
                 return PRESET_SCHEDULE

--- a/custom_components/infinitude_beyond/infinitude/api.py
+++ b/custom_components/infinitude_beyond/infinitude/api.py
@@ -521,47 +521,97 @@ class InfinitudeZone:
         return zone_status
 
     def _update_activities(self) -> None:
-        dt = self._infinitude.system.local_time
+        """Compute scheduled and next activities from the program schedule.
+
+        Handles after-midnight times (e.g. 00:00 / 00:15) that may appear
+        later in the period list by treating backwards time jumps as
+        wrapping into the next day.
+        """
+        now = self._infinitude.system.local_time
+        tz = self._infinitude.system.local_timezone
+
         activity_scheduled = None
         activity_scheduled_start = None
         activity_next = None
         activity_next_start = None
+
+        if now is None:
+            self._activity_scheduled = None
+            self._activity_scheduled_start = None
+            self._activity_next = None
+            self._activity_next_start = None
+            return
+
         try:
-            while activity_next is None:
-                day_name = dt.strftime("%A")
-                program = next(
-                    day
-                    for day in self._config["program"]["day"]
-                    if day["id"] == day_name
+            program_days = self._config.get("program", {}).get("day", [])
+            if not program_days:
+                raise KeyError("Missing program/day schedule in zone config")
+
+            timeline: list[tuple[datetime, str]] = []
+            base_date = now.date()
+
+            for day_offset in (-1, 0, 1, 2):
+                day_date = base_date + timedelta(days=day_offset)
+                day_name = day_date.strftime("%A")
+
+                day_cfg = next(
+                    (d for d in program_days if d.get("id") == day_name), None
                 )
-                for period in program["period"]:
-                    if period["enabled"] == "off":
+                if not day_cfg:
+                    continue
+
+                periods = day_cfg.get("period", [])
+                if not periods:
+                    continue
+
+                wrap_days = 0
+                prev_minutes = None
+
+                for period in periods:
+                    if period.get("enabled") == "off":
                         continue
-                    period_hh, period_mm = period["time"].split(":")
+
+                    time_str = period.get("time")
+                    activity = period.get("activity")
+                    if not time_str or not activity:
+                        continue
+
+                    hh, mm = map(int, time_str.split(":"))
+                    minutes = hh * 60 + mm
+
+                    if prev_minutes is not None and minutes < prev_minutes:
+                        wrap_days += 1
+                    prev_minutes = minutes
+
+                    period_date = day_date + timedelta(days=wrap_days)
                     period_dt = datetime(
-                        year=dt.year,
-                        month=dt.month,
-                        day=dt.day,
-                        hour=int(period_hh),
-                        minute=int(period_mm),
-                        tzinfo=self._infinitude.system.local_timezone,
+                        period_date.year,
+                        period_date.month,
+                        period_date.day,
+                        hh,
+                        mm,
+                        tzinfo=tz,
                     )
-                    if period_dt < dt:
-                        activity_scheduled = period["activity"]
-                        activity_scheduled_start = period_dt
-                    if period_dt >= dt:
-                        activity_next = period["activity"]
-                        activity_next_start = period_dt
-                        break
-                dt = datetime(
-                    year=dt.year,
-                    month=dt.month,
-                    day=dt.day,
-                    tzinfo=self._infinitude.system.local_timezone,
-                ) + timedelta(days=1)
+
+                    timeline.append((period_dt, activity))
+
+            if not timeline:
+                raise ValueError("No enabled periods found in program schedule")
+
+            timeline.sort(key=lambda x: x[0])
+
+            for dt, act in timeline:
+                if dt <= now:
+                    activity_scheduled = act
+                    activity_scheduled_start = dt
+                elif dt > now and activity_next is None:
+                    activity_next = act
+                    activity_next_start = dt
+                    break
+
         except Exception as e:
             _LOGGER.debug(
-                "Error updating activities: %s\nProgram config is %s", e, program
+                "Error updating activities: %s\nZone config is %s", e, self._config
             )
 
         self._activity_scheduled = activity_scheduled


### PR DESCRIPTION
## Summary
Fixes incorrect scheduled activity detection when zone programs include after-midnight times (e.g. `00:00`, `00:15`) and aligns Home Assistant preset reporting with Infinitude’s internal activity/hold model.

## Problem
The existing schedule-walking logic assumes program periods are strictly chronological within a single day. When a schedule wraps past midnight, entries such as `sleep @ 00:00` can be interpreted as earlier the same day, causing the wrong scheduled activity to be inferred.

Separately, Home Assistant preset mode was previously derived from inferred scheduled activity, which could misrepresent Infinitude’s actual state during manual overrides. 

## Changes
- Build a continuous timeline across day boundaries when evaluating zone programs, correctly handling post-midnight entries
- Prevent false “stuck in sleep” or similar states around midnight
- Update HA preset mode reporting to reflect Infinitude’s effective state: current activity is shown when no hold is active; manual overrides are shown as holds
- No API changes; fully backward-compatible

## Behavior Notes
- Activity changes made directly on the thermostat transition the system into the corresponding scheduled activity and are reported as such
- Activity changes initiated via the API are sometimes represented by Infinitude as `manual` with a timed or indefinite hold (particularly if there is a fan setting change between the actives); this PR reflects that model accurately in Home Assistant

## Status
Tested against a live Infinitude system with real configuration and schedules.

## Notes
- Verified against raw Infinitude JSON (`status` and `config`)
- Fixes a long-standing midnight edge case without requiring user schedule changes