### PR TITLE
Fix preset showing "Hold indefinitely" for timed holds

### DIFF
--- a/custom_components/infinitude_beyond/infinitude/api.py
+++ b/custom_components/infinitude_beyond/infinitude/api.py
@@ -677,9 +677,19 @@ class InfinitudeZone:
 
     @property
     def hold_until(self) -> datetime | None:
-        """Hold until time."""
-        val = self._status.get("otmr")
+        """Hold until time.
+
+        Read 'otmr' from config first: Infinitude writes hold/holdActivity/otmr
+        to config synchronously when a hold is set, while the status 'otmr' lags
+        until the thermostat next syncs back. Reading status alone briefly
+        reports a timed hold as indefinite. Fall back to status for any version
+        that doesn't expose otmr in config. An empty value or the literal
+        'forever' (indefinite hold) has no time component.
+        """
+        val = self._config.get("otmr")
         if not isinstance(val, str):
+            val = self._status.get("otmr")
+        if not isinstance(val, str) or ":" not in val:
             return None
         until_hh, until_mm = val.split(":")
         dt = self._infinitude.system.local_time

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -157,13 +157,10 @@ async def test_compare_data_handles_type_change(infinitude):
     assert diff is None or isinstance(diff, dict)
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="Task #1: hold_until reads otmr only from (lagging) status; a timed "
-    "hold is mislabeled INDEFINITE until status catches up. Fix reads config first.",
-)
 async def test_hold_until_prefers_config_otmr(infinitude):
-    # Simulate the window right after a timed hold: config has otmr, status lags.
+    # Right after a timed hold, config carries otmr while status lags. hold_until
+    # must read config first so the hold is reported as timed (UNTIL), not
+    # indefinite. (Regression test for the "Hold indefinitely" mislabel.)
     zcfg = next(z for z in infinitude._config["zones"]["zone"] if z["id"] == "1")
     zcfg["hold"] = "on"
     zcfg["holdActivity"] = "manual"
@@ -174,7 +171,20 @@ async def test_hold_until_prefers_config_otmr(infinitude):
 
     zone = infinitude.zones["1"]
     assert zone.hold_state is HoldState.ON
-    assert zone.hold_mode is HoldMode.UNTIL  # currently INDEFINITE -> the bug
+    assert zone.hold_mode is HoldMode.UNTIL
+
+
+async def test_hold_indefinite_when_otmr_forever(infinitude):
+    # Infinitude stores otmr="forever" for an indefinite hold. hold_until must
+    # treat that as no time component (and not crash on split(":")).
+    zcfg = next(z for z in infinitude._config["zones"]["zone"] if z["id"] == "1")
+    zcfg["hold"] = "on"
+    zcfg["holdActivity"] = "manual"
+    zcfg["otmr"] = "forever"
+
+    zone = infinitude.zones["1"]
+    assert zone.hold_until is None
+    assert zone.hold_mode is HoldMode.INDEFINITE
 
 
 class _LoopGuard(BaseException):


### PR DESCRIPTION
After changing a zone's temperature, the preset would show "Hold indefinitely" even though the hold actually clears at the next scheduled activity.

The hold fields come from two places: `hold` and `holdActivity` are read from config, but `hold_until` was reading `otmr` from status. Infinitude writes `otmr` to config as soon as a hold is set, while the status copy lags until the thermostat syncs back — so in that window a timed hold looks indefinite.

`hold_until` now reads `otmr` from config first and falls back to status, and ignores values with no time component (empty, or "forever" for an indefinite hold). This matches how Infinitude itself derives the preset.

Includes a regression test. Based on #48 — merge that first.
