### PR TITLE
Fix runaway CPU when a zone has no active schedule

### DIFF
--- a/custom_components/infinitude_beyond/infinitude/api.py
+++ b/custom_components/infinitude_beyond/infinitude/api.py
@@ -526,7 +526,9 @@ class InfinitudeZone:
         activity_next = None
         activity_next_start = None
         try:
-            while activity_next is None:
+            # Walk at most one week ahead to find the next scheduled activity.
+            # Without a bound, a fully-disabled schedule loops indefinitely.
+            for _ in range(7):
                 day_name = dt.strftime("%A")
                 program = next(
                     day
@@ -552,6 +554,8 @@ class InfinitudeZone:
                         activity_next = period["activity"]
                         activity_next_start = period_dt
                         break
+                if activity_next is not None:
+                    break
                 dt = datetime(
                     year=dt.year,
                     month=dt.month,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -185,11 +185,6 @@ class _LoopGuard(BaseException):
     """
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="#42: _update_activities walks days forever when no schedule is "
-    "active. Drop xfail once the day-walk is bounded to 7 days.",
-)
 async def test_update_activities_terminates_without_schedule(infinitude, monkeypatch):
     # Swap zone 1 to a fully-disabled schedule (simplified, as connect() stores it).
     from tests.conftest import load_fixture
@@ -198,15 +193,17 @@ async def test_update_activities_terminates_without_schedule(infinitude, monkeyp
     infinitude._config = no_sched
     zone = infinitude.zones["1"]
 
-    # _update_activities advances one day per loop via `timedelta(days=1)`. Trip a
-    # guard once it walks past two weeks -- a bounded (<=7-day) implementation
-    # never gets there; the current unbounded loop does, almost immediately.
-    calls = {"n": 0}
+    # The loop advances one day per iteration via timedelta(days=1). Count only
+    # those day advances (local_timezone also builds timedeltas) and trip a guard
+    # past a week -- a bounded (<=7-day) walk never gets there; the old unbounded
+    # loop would spin into the millions.
+    day_steps = {"n": 0}
 
     def counting_timedelta(*args, **kwargs):
-        calls["n"] += 1
-        if calls["n"] > 14:
-            raise _LoopGuard
+        if kwargs.get("days"):
+            day_steps["n"] += 1
+            if day_steps["n"] > 8:
+                raise _LoopGuard
         return timedelta(*args, **kwargs)
 
     monkeypatch.setattr(api_module, "timedelta", counting_timedelta)
@@ -217,4 +214,5 @@ async def test_update_activities_terminates_without_schedule(infinitude, monkeyp
     except _LoopGuard:
         walked_unbounded = True
 
-    assert not walked_unbounded, "_update_activities walked past 14 days (unbounded)"
+    assert not walked_unbounded, "_update_activities walked past a week (unbounded)"
+    assert zone.activity_next is None  # no enabled schedule -> no next activity


### PR DESCRIPTION
If a zone's schedule has no enabled periods, `_update_activities` would walk forward day by day looking for the next activity and never find one, so it kept going until the date overflowed — pegging a CPU and making HA unresponsive (#42).

It now gives up after a week and leaves the next activity unset. Same approach as the existing #42 PR.

Regression test included.

(Replaces #51, which GitHub auto-closed when the rearchitecture base branch was deleted on merging #48.)
