### PR TITLE
Fix spurious error on temperature/hold changes (#38, #39)

### DIFF
--- a/custom_components/infinitude_beyond/infinitude/api.py
+++ b/custom_components/infinitude_beyond/infinitude/api.py
@@ -1,6 +1,7 @@
 """Define a base client for interacting with Infinitude."""
 
 import asyncio
+import json
 import logging
 from datetime import datetime, timedelta, timezone
 from re import match
@@ -47,6 +48,7 @@ class Infinitude:
         self._config: dict = {}
         self._energy: dict = {}
         self._profile: dict = {}
+        self._warned_post_non_json: bool = False
 
         if not self._session or self._session.closed:
             self._session = ClientSession()
@@ -73,24 +75,56 @@ class Infinitude:
         except ClientError as e:
             _LOGGER.error(e)
 
-    async def _post(self, endpoint: str, data: dict, **kwargs) -> dict:
-        """Make a POST request to Infinitude."""
+    async def _post(self, endpoint: str, data: dict, **kwargs) -> dict | None:
+        """POST to Infinitude.
+
+        Some Infinitude versions return an empty or non-JSON body on a
+        successful POST, and nothing here uses the response. Parse it only when
+        it's there; never let a bad or empty body raise, or a temp/hold change
+        shows an error in HA even though it actually worked.
+        """
         url = f"{self.url}{endpoint}"
         try:
             _LOGGER.debug("POST %s with %s and %s", url, data, kwargs)
             async with self._session.post(url, data=data, **kwargs) as resp:
+                text = await resp.text()
                 _LOGGER.debug(
                     "POST RESPONSE from %s with %s and %s is: %s",
                     url,
                     data,
                     kwargs,
-                    await resp.text(),
+                    text,
                 )
                 resp.raise_for_status()
-                resp_json: dict = await resp.json(content_type=None)
-                return resp_json
+                stripped = text.strip()
+                if stripped:
+                    try:
+                        return json.loads(stripped)
+                    except ValueError:
+                        pass
+                # Empty or non-JSON body: the request still succeeded.
+                self._warn_non_json_post(endpoint)
+                return None
         except ClientError as e:
             _LOGGER.error(e)
+
+    def _warn_non_json_post(self, endpoint: str) -> None:
+        """Log once that Infinitude sent an empty or non-JSON POST response."""
+        if not self._warned_post_non_json:
+            self._warned_post_non_json = True
+            _LOGGER.warning(
+                "Infinitude returned an empty or non-JSON response to POST %s, "
+                "but the request still went through. This usually means an older "
+                "Infinitude; if it keeps happening, upgrade to the latest version. "
+                "Further messages like this are logged at debug level.",
+                endpoint,
+            )
+        else:
+            _LOGGER.debug(
+                "Empty or non-JSON POST response from %s (request still went "
+                "through).",
+                endpoint,
+            )
 
     def _simplify_json(self, data) -> dict:
         """Remove all single item lists and replace with the item."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -72,12 +72,16 @@ def _build_app(payloads: dict, posts: list) -> web.Application:
 
     async def post_config(request):
         await record(request)
-        # Infinitude can return a non-JSON body (or an empty one) on a successful
-        # POST. _post calls resp.json() on it unconditionally, which raises a
-        # JSONDecodeError -- the root of issues #38/#39. (HA's orjson loader also
-        # raises on an empty body; a non-JSON body reproduces it regardless of
-        # which JSON loader is in use.)
+        # Infinitude can return a non-JSON body on a successful POST (notably on
+        # older versions) -- the root of issues #38/#39. _post must handle it
+        # without raising.
         return web.Response(text="Success", content_type="text/plain")
+
+    async def post_empty(request):
+        await record(request)
+        # The other half of #38/#39: an empty body (what HA's orjson loader chokes
+        # on with "unexpected character: line 1 column 1").
+        return web.Response(text="")
 
     async def post_json(request):
         await record(request)
@@ -89,6 +93,7 @@ def _build_app(payloads: dict, posts: list) -> web.Application:
     app.router.add_get("/energy.json", energy)
     app.router.add_get("/profile.json", profile)
     app.router.add_post("/api/config", post_config)
+    app.router.add_post("/api/empty-test", post_empty)
     app.router.add_post("/api/{zone}/activity/{activity}", post_json)
     app.router.add_post("/api/{zone}/hold", post_json)
     return app

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -12,6 +12,7 @@ Tests are grouped into:
 
 from __future__ import annotations
 
+import logging
 from datetime import timedelta
 
 import infinitude.api as api_module
@@ -131,19 +132,28 @@ async def test_set_fan_mode_posts_manual_activity(infinitude):
 
 
 # --------------------------------------------------------------------------- #
-# Regression repros for open bugs (xfail until fixed)
+# POST response handling (#38/#39)
 # --------------------------------------------------------------------------- #
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="#38/#39: _post crashes on a non-JSON/empty 200 body "
-    "(resp.json raises JSONDecodeError). Drop xfail once _post guards this.",
-)
 async def test_post_non_json_body_does_not_crash(infinitude):
-    # The test server returns a non-JSON 200 body for POST /api/config, as
-    # Infinitude does. _post calls resp.json() on it unconditionally and raises.
+    # Older Infinitude returns a non-JSON 200 body to a POST (the test server
+    # sends "Success"); _post must swallow the parse failure, not raise.
     await infinitude.system.set_hvac_mode(HVACMode.HEAT)
+
+
+async def test_post_empty_body_returns_none_and_warns(infinitude, caplog):
+    # An empty body is the exact #38/#39 condition (orjson "char 0"). _post
+    # returns None and logs a one-time hint to upgrade Infinitude.
+    with caplog.at_level(logging.WARNING):
+        result = await infinitude._post("/api/empty-test", {})
+    assert result is None
+    assert "upgrade" in caplog.text.lower()
+
+
+# --------------------------------------------------------------------------- #
+# Regression repros for open bugs (xfail until fixed)
+# --------------------------------------------------------------------------- #
 
 
 @pytest.mark.xfail(


### PR DESCRIPTION
Changing a temperature or hold threw an error in HA even though the change actually went through (#38, #39):

> Failed to perform the action climate/set_temperature. unexpected character: line 1 column 1 (char 0)

`_post` was parsing every POST response as JSON. Some Infinitude versions return an empty or non-JSON body on a successful POST, so the parse failed and surfaced as an action error. Nothing uses that response anyway.

Now it only parses the body when there is one, and returns None otherwise. When it can't parse, it logs a one-time note that this usually means an older Infinitude and to upgrade if it keeps happening.

Tests cover the non-JSON and empty cases.
