### PR TITLE
Report cannot_connect when Infinitude is unreachable (#20)

### DIFF
--- a/custom_components/infinitude_beyond/__init__.py
+++ b/custom_components/infinitude_beyond/__init__.py
@@ -79,8 +79,8 @@ class InfinitudeDataUpdateCoordinator(DataUpdateCoordinator):
         """Fetch data from Infinitude."""
         try:
             await self.infinitude.update()
-        except TimeoutError as err:
-            raise UpdateFailed(f"Timeout while communicating with API: {err}") from err
+        except (TimeoutError, ConnectionError) as err:
+            raise UpdateFailed(f"Error communicating with Infinitude: {err}") from err
 
 
 class InfinitudeEntity(CoordinatorEntity[InfinitudeDataUpdateCoordinator]):

--- a/custom_components/infinitude_beyond/infinitude/api.py
+++ b/custom_components/infinitude_beyond/infinitude/api.py
@@ -65,15 +65,20 @@ class Infinitude:
         return f"{protocol}://{self.host}:{self.port}"
 
     async def _get(self, endpoint: str, **kwargs) -> dict:
-        """Make a GET request to Infinitude."""
+        """GET from Infinitude.
+
+        Raise ConnectionError on any request failure. Returning None here meant
+        the fetchers blew up later on a None response (issue #20); raising lets
+        connect() report it as a connection problem.
+        """
         url = f"{self.url}{endpoint}"
         try:
             async with self._session.get(url, **kwargs) as resp:
-                data: dict = await resp.json(content_type=None)
                 resp.raise_for_status()
-                return data
+                return await resp.json(content_type=None)
         except ClientError as e:
-            _LOGGER.error(e)
+            _LOGGER.error("GET %s failed: %s", url, e)
+            raise ConnectionError from e
 
     async def _post(self, endpoint: str, data: dict, **kwargs) -> dict | None:
         """POST to Infinitude.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -87,11 +87,16 @@ def _build_app(payloads: dict, posts: list) -> web.Application:
         await record(request)
         return web.json_response({})
 
+    async def fail(_):
+        # A failing GET, for the connection-error path (issue #20).
+        return web.Response(status=500)
+
     app = web.Application()
     app.router.add_get("/api/status/", status)
     app.router.add_get("/api/config/", config)
     app.router.add_get("/energy.json", energy)
     app.router.add_get("/profile.json", profile)
+    app.router.add_get("/api/fail", fail)
     app.router.add_post("/api/config", post_config)
     app.router.add_post("/api/empty-test", post_empty)
     app.router.add_post("/api/{zone}/activity/{activity}", post_json)

--- a/tests/ha/test_config_flow.py
+++ b/tests/ha/test_config_flow.py
@@ -9,7 +9,7 @@ from homeassistant import config_entries
 from homeassistant.const import CONF_HOST, CONF_PORT, CONF_SSL
 from homeassistant.data_entry_flow import FlowResultType
 
-from .conftest import ENTRY_DATA, UNIQUE_ID
+from .conftest import BASE, ENTRY_DATA, UNIQUE_ID
 
 
 async def test_form_is_shown(hass):
@@ -50,3 +50,20 @@ async def test_aborts_if_already_configured(hass, mock_infinitude, config_entry)
 
     assert result2["type"] == FlowResultType.ABORT
     assert result2["reason"] == "already_configured"
+
+
+async def test_user_flow_cannot_connect(hass, aioclient_mock):
+    # When the GETs fail, connect() raises ConnectionError and the flow reports
+    # cannot_connect instead of crashing with "Unknown error" (issue #20).
+    for path in ("/api/status/", "/api/config/", "/energy.json", "/profile.json"):
+        aioclient_mock.get(f"{BASE}{path}", status=500)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"], ENTRY_DATA
+    )
+
+    assert result2["type"] == FlowResultType.FORM
+    assert result2["errors"] == {"base": "cannot_connect"}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -151,6 +151,13 @@ async def test_post_empty_body_returns_none_and_warns(infinitude, caplog):
     assert "upgrade" in caplog.text.lower()
 
 
+async def test_get_raises_connection_error_on_failure(infinitude):
+    # A failed GET must raise (not return None), so connect() can report a
+    # connection problem instead of blowing up later in the fetchers (#20).
+    with pytest.raises(ConnectionError):
+        await infinitude._get("/api/fail")
+
+
 # --------------------------------------------------------------------------- #
 # Regression repros for open bugs (xfail until fixed)
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
Adding the integration could fail with "Unknown error" instead of a connection error. When a GET to Infinitude failed, `_get` swallowed it and returned None, then `_fetch_config` hit `'NoneType' object has no attribute 'get'` (#20).

`_get` now raises `ConnectionError` on any request failure. `connect()` lets it propagate, so the config flow maps it to "cannot_connect", and the coordinator treats it like a timeout (`UpdateFailed`) on later polls. Also moved `raise_for_status` ahead of the JSON parse so a bad status doesn't try to decode an error page.

The OverflowError half of #20 (no schedule defined) is already handled by the activity-lookup bound. Tests cover the GET raising and the config flow showing cannot_connect.
