### PR TITLE
Keep set_temperature available in every mode (#25)

### DIFF
--- a/custom_components/infinitude_beyond/climate.py
+++ b/custom_components/infinitude_beyond/climate.py
@@ -102,17 +102,6 @@ class InfinitudeClimate(InfinitudeEntity, ClimateEntity):
         super().__init__(coordinator, zone_id)
 
     @property
-    def supported_features(self):
-        """Return the supported features."""
-        baseline = ClimateEntityFeature.FAN_MODE | ClimateEntityFeature.PRESET_MODE
-        if self.zone.hvac_mode == InfHVACMode.AUTO:
-            return baseline | ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
-        elif self.zone.hvac_mode in [InfHVACMode.HEAT, InfHVACMode.COOL]:
-            return baseline | ClimateEntityFeature.TARGET_TEMPERATURE
-        else:
-            return baseline
-
-    @property
     def temperature_unit(self) -> str:
         """Return the unit of measurement."""
         unit = self.zone.temperature_unit

--- a/tests/ha/test_init.py
+++ b/tests/ha/test_init.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from custom_components.infinitude_beyond.const import DOMAIN
+from homeassistant.components.climate import ClimateEntityFeature
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM
 
@@ -27,6 +28,18 @@ async def test_setup_creates_climate_entities(hass, mock_infinitude, config_entr
     states_by_temp = {s.attributes.get("current_temperature") for s in climate_states}
     assert states_by_temp == {70.0, 68.0}
     assert all(s.state == "heat" for s in climate_states)
+
+
+async def test_climate_target_temperature_supported_in_any_mode(
+    hass, mock_infinitude, config_entry
+):
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    feats = hass.states.async_all("climate")[0].attributes["supported_features"]
+    assert feats & ClimateEntityFeature.TARGET_TEMPERATURE
+    assert feats & ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
 
 
 async def test_unload_entry(hass, mock_infinitude, config_entry):


### PR DESCRIPTION
Setting target temperature would intermittently fail with "entity does not support setting target temperature", and the action would disappear from scripts and the Dev Tools list (#25).

`supported_features` was derived from `hvac_mode` — it advertised `TARGET_TEMPERATURE` only in Heat/Cool, `TARGET_TEMPERATURE_RANGE` only in Auto, and neither in Off/Fan Only. HA caches `supported_features`, so the capability flapped: the action vanished when the system wasn't actively heating/cooling and came back only after a state change forced a refresh (which is why a manual "+" on the card "fixed" it).

It now uses the static `_attr_supported_features` the class already declared (target temperature, range, fan, preset), so the capability is stable and the action is always available. The card still shows a single setpoint vs a range based on `hvac_mode`, and `async_set_temperature` already handles both. For reference, core's `bryant_evolution` (same hardware family) declares both flags statically the same way.
