### PR TITLE
Handle after-midnight schedule wrap and report current activity (#47)

### DIFF
--- a/custom_components/infinitude_beyond/climate.py
+++ b/custom_components/infinitude_beyond/climate.py
@@ -277,15 +277,19 @@ class InfinitudeClimate(InfinitudeEntity, ClimateEntity):
     @property
     def preset_mode(self):
         """Return current preset mode."""
-        # If hold is off, preset is the currently scheduled activity
+        # If hold is off, preset should reflect the effective current activity when available.
+        # This avoids showing "Scheduled activity" (graph) or an out-of-date scheduled activity
+        # when Infinitude reports a different currentActivity.
         if self.zone.hold_mode == InfHoldMode.OFF:
-            if self.zone.activity_scheduled == InfActivity.HOME:
+            activity = self.zone.activity_current or self.zone.activity_scheduled
+
+            if activity == InfActivity.HOME:
                 return PRESET_HOME
-            elif self.zone.activity_scheduled == InfActivity.AWAY:
+            elif activity == InfActivity.AWAY:
                 return PRESET_AWAY
-            elif self.zone.activity_scheduled == InfActivity.SLEEP:
+            elif activity == InfActivity.SLEEP:
                 return PRESET_SLEEP
-            elif self.zone.activity_scheduled == InfActivity.WAKE:
+            elif activity == InfActivity.WAKE:
                 return PRESET_WAKE
             else:
                 return PRESET_SCHEDULE

--- a/custom_components/infinitude_beyond/infinitude/api.py
+++ b/custom_components/infinitude_beyond/infinitude/api.py
@@ -559,51 +559,97 @@ class InfinitudeZone:
         return zone_status
 
     def _update_activities(self) -> None:
-        dt = self._infinitude.system.local_time
+        """Compute scheduled and next activities from the program schedule.
+
+        Handles after-midnight times (e.g. 00:00 / 00:15) that may appear
+        later in the period list by treating backwards time jumps as
+        wrapping into the next day.
+        """
+        now = self._infinitude.system.local_time
+        tz = self._infinitude.system.local_timezone
+
         activity_scheduled = None
         activity_scheduled_start = None
         activity_next = None
         activity_next_start = None
+
+        if now is None:
+            self._activity_scheduled = None
+            self._activity_scheduled_start = None
+            self._activity_next = None
+            self._activity_next_start = None
+            return
+
         try:
-            # Walk at most one week ahead to find the next scheduled activity.
-            # Without a bound, a fully-disabled schedule loops indefinitely.
-            for _ in range(7):
-                day_name = dt.strftime("%A")
-                program = next(
-                    day
-                    for day in self._config["program"]["day"]
-                    if day["id"] == day_name
+            program_days = self._config.get("program", {}).get("day", [])
+            if not program_days:
+                raise KeyError("Missing program/day schedule in zone config")
+
+            timeline: list[tuple[datetime, str]] = []
+            base_date = now.date()
+
+            for day_offset in (-1, 0, 1, 2):
+                day_date = base_date + timedelta(days=day_offset)
+                day_name = day_date.strftime("%A")
+
+                day_cfg = next(
+                    (d for d in program_days if d.get("id") == day_name), None
                 )
-                for period in program["period"]:
-                    if period["enabled"] == "off":
+                if not day_cfg:
+                    continue
+
+                periods = day_cfg.get("period", [])
+                if not periods:
+                    continue
+
+                wrap_days = 0
+                prev_minutes = None
+
+                for period in periods:
+                    if period.get("enabled") == "off":
                         continue
-                    period_hh, period_mm = period["time"].split(":")
+
+                    time_str = period.get("time")
+                    activity = period.get("activity")
+                    if not time_str or not activity:
+                        continue
+
+                    hh, mm = map(int, time_str.split(":"))
+                    minutes = hh * 60 + mm
+
+                    if prev_minutes is not None and minutes < prev_minutes:
+                        wrap_days += 1
+                    prev_minutes = minutes
+
+                    period_date = day_date + timedelta(days=wrap_days)
                     period_dt = datetime(
-                        year=dt.year,
-                        month=dt.month,
-                        day=dt.day,
-                        hour=int(period_hh),
-                        minute=int(period_mm),
-                        tzinfo=self._infinitude.system.local_timezone,
+                        period_date.year,
+                        period_date.month,
+                        period_date.day,
+                        hh,
+                        mm,
+                        tzinfo=tz,
                     )
-                    if period_dt < dt:
-                        activity_scheduled = period["activity"]
-                        activity_scheduled_start = period_dt
-                    if period_dt >= dt:
-                        activity_next = period["activity"]
-                        activity_next_start = period_dt
-                        break
-                if activity_next is not None:
+
+                    timeline.append((period_dt, activity))
+
+            if not timeline:
+                raise ValueError("No enabled periods found in program schedule")
+
+            timeline.sort(key=lambda x: x[0])
+
+            for dt, act in timeline:
+                if dt <= now:
+                    activity_scheduled = act
+                    activity_scheduled_start = dt
+                elif dt > now and activity_next is None:
+                    activity_next = act
+                    activity_next_start = dt
                     break
-                dt = datetime(
-                    year=dt.year,
-                    month=dt.month,
-                    day=dt.day,
-                    tzinfo=self._infinitude.system.local_timezone,
-                ) + timedelta(days=1)
+
         except Exception as e:
             _LOGGER.debug(
-                "Error updating activities: %s\nProgram config is %s", e, program
+                "Error updating activities: %s\nZone config is %s", e, self._config
             )
 
         self._activity_scheduled = activity_scheduled

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -18,6 +18,7 @@ from datetime import timedelta
 import infinitude.api as api_module
 import pytest
 from infinitude.const import (
+    Activity,
     FanMode,
     HoldMode,
     HoldState,
@@ -243,3 +244,35 @@ async def test_update_activities_terminates_without_schedule(infinitude, monkeyp
 
     assert not walked_unbounded, "_update_activities walked past a week (unbounded)"
     assert zone.activity_next is None  # no enabled schedule -> no next activity
+
+
+async def test_update_activities_handles_after_midnight_wrap(infinitude):
+    # A period whose time wraps past midnight (sleep@00:00 listed after wake@06:00)
+    # belongs to the next day, not the same day. The fixture clock is Monday 08:00,
+    # so the active activity is wake -- not the midnight sleep entry (#47).
+    days = [
+        "Sunday",
+        "Monday",
+        "Tuesday",
+        "Wednesday",
+        "Thursday",
+        "Friday",
+        "Saturday",
+    ]
+    zcfg = next(z for z in infinitude._config["zones"]["zone"] if z["id"] == "1")
+    zcfg["program"]["day"] = [
+        {
+            "id": d,
+            "period": [
+                {"id": "1", "time": "06:00", "activity": "wake", "enabled": "on"},
+                {"id": "2", "time": "00:00", "activity": "sleep", "enabled": "on"},
+            ],
+        }
+        for d in days
+    ]
+
+    zone = infinitude.zones["1"]
+    zone._update_activities()
+
+    assert zone.activity_scheduled is Activity.WAKE
+    assert zone.activity_next is Activity.SLEEP


### PR DESCRIPTION
@yargok's #47 rebased onto `next`. It conflicted with the bounded `_update_activities` from the no-schedule fix, but the timeline approach is bounded on its own, so it cleanly replaces that loop.

It builds a sorted timeline of enabled periods across a day window and treats a backwards time jump as a wrap past midnight, so a `00:00` period lands on the next day instead of the same day. It also reports the current activity rather than the inferred scheduled one when no hold is active.

Adds tests for the midnight wrap and confirms the no-schedule case still terminates. Supersedes #47 — kept Jerry's commit so authorship is preserved.
