### PR TITLE
Take ODU modulation (#44) and only register hardware sensors when reported

### DIFF
--- a/custom_components/infinitude_beyond/infinitude/api.py
+++ b/custom_components/infinitude_beyond/infinitude/api.py
@@ -519,6 +519,25 @@ class InfinitudeSystem:
         return None
 
     @property
+    def odu_modulation(self) -> int | None:
+        """Outdoor unit compressor modulation percentage.
+
+        Only get this if the ODU type is 'proteus' or 'gs3ngipac'
+        """
+        odu = self._status.get("odu")
+        if not odu:
+            return None
+        if odu.get("type") in ["proteus", "gs3ngipac"]:
+            odu_opstat = odu.get("opstat")
+            if odu_opstat.isnumeric():
+                return int(odu_opstat)
+            if odu_opstat == "dehumidify":
+                return 1
+            if odu_opstat == "off":
+                return 0
+        return None
+
+    @property
     def energy(self) -> dict | None:
         """Energy data."""
         if isinstance(self._energy, dict) and self._energy != {}:

--- a/custom_components/infinitude_beyond/infinitude/api.py
+++ b/custom_components/infinitude_beyond/infinitude/api.py
@@ -491,6 +491,16 @@ class InfinitudeSystem:
         return int(val)
 
     @property
+    def has_idu(self) -> bool:
+        """Whether the system reports indoor unit runtime data.
+
+        Variable/communicating indoor units publish an ``idu`` block; simpler
+        units (e.g. a fancoil) don't. Used to decide whether the airflow sensor
+        is worth registering at all.
+        """
+        return self._status.get("idu") is not None
+
+    @property
     def airflow_cfm(self) -> float | None:
         """System airflow in CFM."""
         idu = self._status.get("idu")

--- a/custom_components/infinitude_beyond/sensor.py
+++ b/custom_components/infinitude_beyond/sensor.py
@@ -99,6 +99,12 @@ SYSTEM_SENSORS: tuple[InfinitudeSensorDescription, ...] = (
         native_unit_of_measurement="%",
         value_fn=lambda entity: entity.system.idu_modulation,
     ),
+    InfinitudeSensorDescription(
+        key="odu_modulation",
+        name="ODU modulation",
+        native_unit_of_measurement="%",
+        value_fn=lambda entity: entity.system.odu_modulation,
+    ),
 )
 
 ZONE_SENSORS: tuple[InfinitudeSensorDescription, ...] = (

--- a/custom_components/infinitude_beyond/sensor.py
+++ b/custom_components/infinitude_beyond/sensor.py
@@ -27,13 +27,22 @@ class InfinitudeSensorDescriptionMixin:
     """Mixin for Infinitude sensor."""
 
     value_fn: Callable[[InfinitudeEntity], StateType]
+    # Whether to register the sensor at all. Defaults to always; set it for
+    # sensors that only apply to certain hardware so we don't create entities
+    # that can never report a value.
+    exists_fn: Callable[[InfinitudeEntity], bool] = lambda _entity: True
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class InfinitudeSensorDescription(
     SensorEntityDescription, InfinitudeSensorDescriptionMixin
 ):
-    """Class describing Infinitude sensor entities."""
+    """Class describing Infinitude sensor entities.
+
+    ``kw_only`` keeps the inherited required fields from clashing with the
+    mixin's defaulted ``exists_fn``; every description already passes its
+    fields by keyword.
+    """
 
 
 SYSTEM_SENSORS: tuple[InfinitudeSensorDescription, ...] = (
@@ -92,18 +101,24 @@ SYSTEM_SENSORS: tuple[InfinitudeSensorDescription, ...] = (
         # device_class=SensorDeviceClass.VOLUME_FLOW_RATE,
         native_unit_of_measurement="ft³/min",
         value_fn=lambda entity: entity.system.airflow_cfm,
+        # Airflow reads as None when idle, so gate on the IDU reporting at all.
+        exists_fn=lambda entity: entity.system.has_idu,
     ),
     InfinitudeSensorDescription(
         key="idu_modulation",
         name="IDU modulation",
         native_unit_of_measurement="%",
         value_fn=lambda entity: entity.system.idu_modulation,
+        # Only a modulating furnace reports this; non-None means the IDU does.
+        exists_fn=lambda entity: entity.system.idu_modulation is not None,
     ),
     InfinitudeSensorDescription(
         key="odu_modulation",
         name="ODU modulation",
         native_unit_of_measurement="%",
         value_fn=lambda entity: entity.system.odu_modulation,
+        # Only a modulating outdoor unit reports this.
+        exists_fn=lambda entity: entity.system.odu_modulation is not None,
     ),
 )
 
@@ -181,13 +196,15 @@ async def async_setup_entry(
     coordinator = hass.data[DOMAIN][config_entry.entry_id]
     entities = []
     for entity_description in SYSTEM_SENSORS:
-        entities.append(InfinitudeSensorEntity(coordinator, entity_description))
+        entity = InfinitudeSensorEntity(coordinator, entity_description)
+        if entity_description.exists_fn(entity):
+            entities.append(entity)
     zones = [z for z in coordinator.infinitude.zones.values() if z.enabled]
     for zone in zones:
         for entity_description in ZONE_SENSORS:
-            entities.append(
-                InfinitudeSensorEntity(coordinator, entity_description, zone.id)
-            )
+            entity = InfinitudeSensorEntity(coordinator, entity_description, zone.id)
+            if entity_description.exists_fn(entity):
+                entities.append(entity)
     async_add_entities(entities)
 
 

--- a/tests/ha/test_sensor.py
+++ b/tests/ha/test_sensor.py
@@ -1,0 +1,22 @@
+"""Layer 2 — sensor registration."""
+
+from __future__ import annotations
+
+
+async def test_modulation_sensors_only_register_when_reported(
+    hass, mock_infinitude, config_entry
+):
+    # The fixture system reports an IDU (furnacemodulating, with airflow) but no
+    # ODU. So IDU modulation and Airflow register; ODU modulation does not,
+    # rather than sitting on the device page as a permanent "unknown".
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    names = {
+        s.attributes.get("friendly_name", "")
+        for s in hass.states.async_all("sensor")
+    }
+    assert any(n.endswith("IDU modulation") for n in names)
+    assert any(n.endswith("Airflow") for n in names)
+    assert not any(n.endswith("ODU modulation") for n in names)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -77,6 +77,24 @@ async def test_idu_modulation(infinitude):
     # idu type is 'furnacemodulating' with opstat 35 in the fixture
     assert infinitude.system.idu_modulation == 35
     assert infinitude.system.airflow_cfm == 800.0
+    assert infinitude.system.has_idu is True
+
+
+async def test_odu_modulation(infinitude):
+    # The fixture has no odu block, so there's nothing to report.
+    assert infinitude.system.odu_modulation is None
+
+    odu = infinitude._status["odu"] = {"type": "proteus"}
+    odu["opstat"] = "45"
+    assert infinitude.system.odu_modulation == 45
+    odu["opstat"] = "dehumidify"
+    assert infinitude.system.odu_modulation == 1
+    odu["opstat"] = "off"
+    assert infinitude.system.odu_modulation == 0
+
+    # A unit type we don't read modulation from reports nothing.
+    infinitude._status["odu"] = {"type": "ac2stg", "opstat": "60"}
+    assert infinitude.system.odu_modulation is None
 
 
 async def test_zone_temperatures(infinitude):


### PR DESCRIPTION
Takes #44 (ODU modulation, thanks @LXXero) and tidies up how the hardware sensors register.

The modulation and airflow sensors only apply to certain equipment. On everything else they've been sitting on the System device reading "unknown" forever. This adds an `exists_fn` to the sensor description so we skip registering one when the unit isn't reporting it: airflow when there's no IDU block, IDU/ODU modulation when the unit type doesn't expose it.

Closes #44.