### PR TITLE
Add a connectivity sensor and quiet repeated GET errors (#29)

### DIFF
--- a/custom_components/infinitude_beyond/binary_sensor.py
+++ b/custom_components/infinitude_beyond/binary_sensor.py
@@ -5,10 +5,12 @@ from collections.abc import Callable
 from dataclasses import dataclass
 
 from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
     BinarySensorEntity,
     BinarySensorEntityDescription,
 )
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import StateType
@@ -60,7 +62,7 @@ async def async_setup_entry(
 ) -> None:
     """Set up Infinitude binary sensors from config entry."""
     coordinator = hass.data[DOMAIN][config_entry.entry_id]
-    entities = []
+    entities = [InfinitudeConnectivityBinarySensorEntity(coordinator)]
     for entity_description in SYSTEM_BINARY_SENSORS:
         entities.append(InfinitudeBinarySensorEntity(coordinator, entity_description))
     zones = [z for z in coordinator.infinitude.zones.values() if z.enabled]
@@ -98,3 +100,27 @@ class InfinitudeBinarySensorEntity(InfinitudeEntity, BinarySensorEntity):
         if self.entity_description.extra_state_attributes_fn is not None:
             return self.entity_description.extra_state_attributes_fn(self)
         return None
+
+
+class InfinitudeConnectivityBinarySensorEntity(InfinitudeEntity, BinarySensorEntity):
+    """Reports whether Home Assistant can reach Infinitude.
+
+    This one stays available even when the connection is down -- a normal
+    coordinator entity goes unavailable the moment a fetch fails, which is
+    exactly when you'd want to read it. So it overrides availability and
+    reports the coordinator's last fetch result instead.
+    """
+
+    _attr_name = "Connectivity"
+    _attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    @property
+    def available(self) -> bool:
+        """The connectivity sensor itself is always available."""
+        return True
+
+    @property
+    def is_on(self) -> bool:
+        """True while the last fetch from Infinitude succeeded."""
+        return self.coordinator.last_update_success

--- a/custom_components/infinitude_beyond/infinitude/api.py
+++ b/custom_components/infinitude_beyond/infinitude/api.py
@@ -77,7 +77,10 @@ class Infinitude:
                 resp.raise_for_status()
                 return await resp.json(content_type=None)
         except ClientError as e:
-            _LOGGER.error("GET %s failed: %s", url, e)
+            # Logged at debug only: during an outage this fires every update
+            # cycle. The coordinator logs the first failure and the recovery,
+            # and the connectivity sensor tracks the state.
+            _LOGGER.debug("GET %s failed: %s", url, e)
             raise ConnectionError from e
 
     async def _post(self, endpoint: str, data: dict, **kwargs) -> dict | None:

--- a/tests/ha/test_binary_sensor.py
+++ b/tests/ha/test_binary_sensor.py
@@ -1,0 +1,41 @@
+"""Layer 2 — connectivity binary sensor."""
+
+from __future__ import annotations
+
+from custom_components.infinitude_beyond.const import DOMAIN
+
+
+def _connectivity_state(hass):
+    for state in hass.states.async_all("binary_sensor"):
+        if state.attributes.get("device_class") == "connectivity":
+            return state
+    return None
+
+
+async def test_connectivity_sensor_tracks_coordinator_without_going_unavailable(
+    hass, mock_infinitude, config_entry
+):
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    conn = _connectivity_state(hass)
+    assert conn is not None, "expected a connectivity binary sensor"
+    assert conn.state == "on"  # a successful setup means connected
+
+    # A failed fetch must flip it to 'off' (disconnected) -- not 'unavailable',
+    # which is what a plain coordinator entity would do and would make it useless.
+    coordinator = hass.data[DOMAIN][config_entry.entry_id]
+    coordinator.last_update_success = False
+    coordinator.async_update_listeners()
+    await hass.async_block_till_done()
+
+    conn = hass.states.get(conn.entity_id)
+    assert conn.state == "off"
+
+    # And back on when the connection recovers.
+    coordinator.last_update_success = True
+    coordinator.async_update_listeners()
+    await hass.async_block_till_done()
+
+    assert hass.states.get(conn.entity_id).state == "on"


### PR DESCRIPTION
For #29. Two changes.

A diagnostic connectivity binary sensor on the system device, so there's an actual entity you can check and automate on for whether HA can reach Infinitude. The important bit: it overrides availability to stay available when the connection drops and reports `coordinator.last_update_success`, so it reads connected/disconnected instead of going unavailable the way every other entity does (which is exactly when you'd want to read it). Its state changes also land in the logbook, which covers the "Server Reconnected" half of the request.

And it drops the per-request GET error to debug. During an outage that fired every update cycle (~every 15s). The coordinator already logs the first failure and the recovery, so nothing useful is lost.

Closes #29.