### PR TITLE
Key identity on the config entry, not the serial (#40)

### DIFF
--- a/custom_components/infinitude_beyond/__init__.py
+++ b/custom_components/infinitude_beyond/__init__.py
@@ -6,8 +6,9 @@ from datetime import timedelta
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_PORT, CONF_SSL, Platform
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import (
@@ -32,6 +33,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     coordinator = InfinitudeDataUpdateCoordinator(
         hass,
+        entry,
         entry.data[CONF_HOST],
         entry.data[CONF_PORT],
         entry.data[CONF_SSL],
@@ -42,9 +44,83 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         _LOGGER.error("Error connecting to Infinitude: %s", ex)
         raise ConfigEntryNotReady from ex
 
+    _async_migrate_to_entry_id(hass, entry)
+
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
+
+
+def _rebase_id(old: str, base: str, markers: tuple[str, ...]) -> str | None:
+    """Replace the prefix before the earliest marker with ``base``.
+
+    Returns None when no marker is present or the id is already rebased.
+    """
+    best = None
+    for marker in markers:
+        idx = old.find(marker)
+        if idx != -1 and (best is None or idx < best):
+            best = idx
+    if best is None:
+        return None
+    new = f"{base}{old[best:]}"
+    return new if new != old else None
+
+
+def _is_none_prefixed(uid: str) -> bool:
+    return uid.startswith("None_")
+
+
+@callback
+def _async_migrate_to_entry_id(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Rebase entity and device ids onto the config entry id.
+
+    Preserves entity_id (and history). When an install already split, the
+    serial-based entry wins and the "None" duplicate is left in place. Runs
+    before platforms register so entities bind to the migrated rows.
+    """
+    base = entry.entry_id
+    ent_reg = er.async_get(hass)
+    entities = er.async_entries_for_config_entry(ent_reg, entry.entry_id)
+
+    taken = {e.unique_id for e in entities}
+    groups: dict[str, list[er.RegistryEntry]] = {}
+    for ent in entities:
+        target = _rebase_id(ent.unique_id, base, ("_zone_", "_system_"))
+        if target is not None:
+            groups.setdefault(target, []).append(ent)
+
+    for target, candidates in groups.items():
+        if target in taken:
+            continue
+        candidates.sort(key=lambda e: _is_none_prefixed(e.unique_id))
+        ent_reg.async_update_entity(candidates[0].entity_id, new_unique_id=target)
+        taken.add(target)
+
+    dev_reg = dr.async_get(hass)
+    devices = dr.async_entries_for_config_entry(dev_reg, entry.entry_id)
+    taken_idents = {
+        ident for d in devices for dom, ident in d.identifiers if dom == DOMAIN
+    }
+    devices.sort(
+        key=lambda d: any(
+            _is_none_prefixed(i) for dom, i in d.identifiers if dom == DOMAIN
+        )
+    )
+    for device in devices:
+        new_identifiers = set()
+        changed = False
+        for domain, ident in device.identifiers:
+            new_ident = ident
+            if domain == DOMAIN:
+                rebased = _rebase_id(ident, base, ("_zone_", "_system"))
+                if rebased is not None and rebased not in taken_idents:
+                    new_ident = rebased
+                    changed = True
+                    taken_idents.add(rebased)
+            new_identifiers.add((domain, new_ident))
+        if changed:
+            dev_reg.async_update_device(device.id, new_identifiers=new_identifiers)
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -58,11 +134,19 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 class InfinitudeDataUpdateCoordinator(DataUpdateCoordinator):
     """Data update coordinator for Infinitude."""
 
-    def __init__(self, hass: HomeAssistant, host: str, port: int, ssl: bool) -> None:
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        entry: ConfigEntry,
+        host: str,
+        port: int,
+        ssl: bool,
+    ) -> None:
         """Initialize the coordinator."""
         super().__init__(
             hass,
             _LOGGER,
+            config_entry=entry,
             name=f"{host}:{port}",
             update_interval=timedelta(seconds=UPDATE_INTERVAL),
         )
@@ -103,11 +187,16 @@ class InfinitudeEntity(CoordinatorEntity[InfinitudeDataUpdateCoordinator]):
         super().__init__(coordinator)
 
     @property
+    def _id_base(self) -> str:
+        """Stable identity prefix for entities and devices."""
+        return self.coordinator.config_entry.entry_id
+
+    @property
     def unique_id(self) -> str:
         """Return the unique id."""
         if self.zone:
-            return f"{self.system.serial}_zone_{self.zone.id}_{self.name}"
-        return f"{self.system.serial}_system_{self.name}"
+            return f"{self._id_base}_zone_{self.zone.id}_{self.name}"
+        return f"{self._id_base}_system_{self.name}"
 
     @property
     def device_info(self) -> DeviceInfo:
@@ -120,10 +209,10 @@ class InfinitudeEntity(CoordinatorEntity[InfinitudeDataUpdateCoordinator]):
                 name = self.zone.name
             else:
                 name = f"Zone {self.zone.id}"
-            identifier = f"{self.infinitude.system.serial}_zone_{self.zone.id}"
+            identifier = f"{self._id_base}_zone_{self.zone.id}"
         else:
             name = "Infinitude System"
-            identifier = f"{self.system.serial}_system"
+            identifier = f"{self._id_base}_system"
 
         return DeviceInfo(
             identifiers={(DOMAIN, identifier)},

--- a/custom_components/infinitude_beyond/infinitude/api.py
+++ b/custom_components/infinitude_beyond/infinitude/api.py
@@ -77,9 +77,7 @@ class Infinitude:
                 resp.raise_for_status()
                 return await resp.json(content_type=None)
         except ClientError as e:
-            # Logged at debug only: during an outage this fires every update
-            # cycle. The coordinator logs the first failure and the recovery,
-            # and the connectivity sensor tracks the state.
+            # Debug only: this fires every update cycle during an outage.
             _LOGGER.debug("GET %s failed: %s", url, e)
             raise ConnectionError from e
 

--- a/tests/ha/test_migration.py
+++ b/tests/ha/test_migration.py
@@ -1,0 +1,76 @@
+"""Layer 2 — identity migration off the serial number (issue #40)."""
+
+from __future__ import annotations
+
+import pytest
+from custom_components.infinitude_beyond.const import DOMAIN
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+
+# Matches the serial in the profile fixture.
+SERIAL = "0000W000000"
+
+
+@pytest.mark.parametrize("old_prefix", [SERIAL, "None"], ids=["serial", "none"])
+async def test_entity_unique_ids_migrate_to_entry_id(
+    hass, mock_infinitude, config_entry, old_prefix
+):
+    # Pre-existing entity keyed on the old (serial or "None") prefix.
+    config_entry.add_to_hass(hass)
+    ent_reg = er.async_get(hass)
+    old = ent_reg.async_get_or_create(
+        "sensor", DOMAIN, f"{old_prefix}_system_HVAC mode", config_entry=config_entry
+    )
+    entity_id = old.entity_id
+
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Same entity_id (so recorder history and template helpers survive), but the
+    # unique_id is rebased onto the stable config entry id.
+    migrated = ent_reg.async_get(entity_id)
+    assert migrated is not None
+    assert migrated.unique_id == f"{config_entry.entry_id}_system_HVAC mode"
+
+
+async def test_duplicate_prefers_serial_entry(hass, mock_infinitude, config_entry):
+    # An already-split install: the serial entry holds history, the "None" one
+    # is the empty duplicate. The serial one must win the migration.
+    config_entry.add_to_hass(hass)
+    ent_reg = er.async_get(hass)
+    serial_entry = ent_reg.async_get_or_create(
+        "sensor", DOMAIN, f"{SERIAL}_system_HVAC mode", config_entry=config_entry
+    )
+    none_entry = ent_reg.async_get_or_create(
+        "sensor", DOMAIN, "None_system_HVAC mode", config_entry=config_entry
+    )
+
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Serial entry rebased onto the entry id (and stays live); the None
+    # duplicate is left untouched for manual cleanup.
+    assert (
+        ent_reg.async_get(serial_entry.entity_id).unique_id
+        == f"{config_entry.entry_id}_system_HVAC mode"
+    )
+    assert ent_reg.async_get(none_entry.entity_id).unique_id == "None_system_HVAC mode"
+
+
+async def test_device_identifier_migrates_to_entry_id(
+    hass, mock_infinitude, config_entry
+):
+    config_entry.add_to_hass(hass)
+    dev_reg = dr.async_get(hass)
+    old_device = dev_reg.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={(DOMAIN, f"{SERIAL}_system")},
+        name="Infinitude System",
+    )
+
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    migrated = dev_reg.async_get(old_device.id)
+    assert migrated is not None
+    assert (DOMAIN, f"{config_entry.entry_id}_system") in migrated.identifiers
+    assert (DOMAIN, f"{SERIAL}_system") not in migrated.identifiers


### PR DESCRIPTION
Closes #40.

The serial isn't reported on every status (reboots, serial-bus monitoring), so the `unique_id`s and device identifiers built from it flipped between the real serial and "None". HA treated that as new entities, so it spawned duplicate devices and orphaned the originals.

Identity now uses the config entry id, which is stable across reboots and data-source changes. The serial still shows on the device page; it's just no longer the identity key. A one-time migration rebases existing registry entries onto the entry id, preserving `entity_id` so recorder history and template helpers carry over.

One limitation worth noting: an install that already split into two entities can't have its history auto-merged across two `entity_id`s. The migration makes the serial-based (history-bearing) entry go live again and leaves the empty "None" duplicate to delete, and stops any further proliferation.

Also trims an over-long comment on the GET debug log from #29 — that rationale belongs in the commit, not inline.