### PR TITLE
Add heat source control and equipment status sensors (#9, #31)

### DIFF
--- a/custom_components/infinitude_beyond/climate.py
+++ b/custom_components/infinitude_beyond/climate.py
@@ -35,6 +35,7 @@ from .const import (
 from .infinitude.const import (
     Activity as InfActivity,
     FanMode as InfFanMode,
+    HeatSource as InfHeatSource,
     HoldMode as InfHoldMode,
     HVACAction as InfHVACAction,
     HVACMode as InfHVACMode,
@@ -48,6 +49,8 @@ ATTR_HOLD_ACTIVITY = "activity"
 ATTR_HOLD_MODE = "mode"
 ATTR_HOLD_UNTIL = "until"
 SERVICE_SET_HOLD_MODE = "set_hold_mode"
+ATTR_HEAT_SOURCE = "heat_source"
+SERVICE_SET_HEAT_SOURCE = "set_heat_source"
 
 
 async def async_setup_entry(
@@ -82,6 +85,12 @@ async def async_setup_entry(
             ),
         },
         "async_set_hold_mode",
+    )
+
+    platform.async_register_entity_service(
+        SERVICE_SET_HEAT_SOURCE,
+        {vol.Required(ATTR_HEAT_SOURCE): vol.In([hs.value for hs in InfHeatSource])},
+        "async_set_heat_source",
     )
 
 
@@ -371,3 +380,8 @@ class InfinitudeClimate(InfinitudeEntity, ClimateEntity):
         await self.zone.set_hold_mode(
             mode=hold_mode, activity=hold_activity, until=hold_until
         )
+
+    async def async_set_heat_source(self, heat_source):
+        """Set the heat source for a dual-fuel system."""
+        source = next((hs for hs in InfHeatSource if hs.value == heat_source), None)
+        await self.system.set_heat_source(source)

--- a/custom_components/infinitude_beyond/infinitude/api.py
+++ b/custom_components/infinitude_beyond/infinitude/api.py
@@ -12,6 +12,7 @@ from aiohttp.client_exceptions import ClientError
 from .const import (
     Activity,
     FanMode,
+    HeatSource,
     HoldMode,
     HoldState,
     HumidifierState,
@@ -25,6 +26,34 @@ _LOGGER = logging.getLogger(__name__)
 
 CONNECT_TIMEOUT: int = 30
 UPDATE_TIMEOUT: int = 30
+
+# Known equipment status values -> translation slugs. Unknown values pass
+# through as-is (see _opstat_slug).
+_OPSTAT_SLUGS = {
+    "off": "off",
+    "stage 1": "stage_1",
+    "stage 2": "stage_2",
+    "stage 3": "stage_3",
+    "stage 4": "stage_4",
+    "stage 5": "stage_5",
+    "defrost": "defrost",
+    "dehumidify": "dehumidify",
+}
+
+# Infinitude config <-> heat source slug.
+_HEAT_SOURCE_FROM_CONFIG = {
+    "system": HeatSource.SYSTEM,
+    "idu only": HeatSource.GAS,
+    "odu only": HeatSource.HEATPUMP,
+}
+_HEAT_SOURCE_TO_CONFIG = {v: k for k, v in _HEAT_SOURCE_FROM_CONFIG.items()}
+
+
+def _opstat_slug(value) -> str | None:
+    """Slug for a known staging status; the raw value for anything else."""
+    if value in (None, ""):
+        return None
+    return _OPSTAT_SLUGS.get(str(value).strip().lower(), str(value))
 
 
 class Infinitude:
@@ -547,6 +576,46 @@ class InfinitudeSystem:
             if odu_opstat == "off":
                 return 0
         return None
+
+    @property
+    def furnace_status(self) -> str | None:
+        """Indoor unit operating status."""
+        idu = self._status.get("idu")
+        if not idu:
+            return None
+        return _opstat_slug(idu.get("opstat"))
+
+    @property
+    def heatpump_status(self) -> str | None:
+        """Outdoor unit operating status (heat pump stage)."""
+        odu = self._status.get("odu")
+        if not odu:
+            return None
+        return _opstat_slug(odu.get("opstat"))
+
+    @property
+    def heatpump_mode(self) -> str | None:
+        """Outdoor unit operating mode."""
+        odu = self._status.get("odu")
+        if not odu:
+            return None
+        val = odu.get("opmode")
+        return str(val) if val else None
+
+    @property
+    def heat_source(self) -> str | None:
+        """Configured heat source for dual-fuel systems."""
+        hs = self._config.get("heatsource")
+        if not hs:
+            return None
+        mapped = _HEAT_SOURCE_FROM_CONFIG.get(str(hs).strip().lower())
+        return mapped.value if mapped else None
+
+    async def set_heat_source(self, heatsource: HeatSource) -> None:
+        """Set the heat source for a dual-fuel system."""
+        data = {"heatsource": _HEAT_SOURCE_TO_CONFIG[heatsource]}
+        await self._infinitude._post("/api/config", data)
+        await self._infinitude.update()
 
     @property
     def energy(self) -> dict | None:

--- a/custom_components/infinitude_beyond/infinitude/const.py
+++ b/custom_components/infinitude_beyond/infinitude/const.py
@@ -85,3 +85,11 @@ class HumidifierState(Enum):
 
     ON = "on"
     OFF = "off"
+
+
+class HeatSource(Enum):
+    """Heat source for dual-fuel systems (slug values; display via translation)."""
+
+    SYSTEM = "system"
+    GAS = "gas"
+    HEATPUMP = "heat_pump"

--- a/custom_components/infinitude_beyond/sensor.py
+++ b/custom_components/infinitude_beyond/sensor.py
@@ -120,6 +120,30 @@ SYSTEM_SENSORS: tuple[InfinitudeSensorDescription, ...] = (
         # Only a modulating outdoor unit reports this.
         exists_fn=lambda entity: entity.system.odu_modulation is not None,
     ),
+    InfinitudeSensorDescription(
+        key="furnace_status",
+        translation_key="furnace_status",
+        value_fn=lambda entity: entity.system.furnace_status,
+        exists_fn=lambda entity: entity.system.furnace_status is not None,
+    ),
+    InfinitudeSensorDescription(
+        key="heatpump_status",
+        translation_key="heatpump_status",
+        value_fn=lambda entity: entity.system.heatpump_status,
+        exists_fn=lambda entity: entity.system.heatpump_status is not None,
+    ),
+    InfinitudeSensorDescription(
+        key="heatpump_mode",
+        translation_key="heatpump_mode",
+        value_fn=lambda entity: entity.system.heatpump_mode,
+        exists_fn=lambda entity: entity.system.heatpump_mode is not None,
+    ),
+    InfinitudeSensorDescription(
+        key="heat_source",
+        translation_key="heat_source",
+        value_fn=lambda entity: entity.system.heat_source,
+        exists_fn=lambda entity: entity.system.heat_source is not None,
+    ),
 )
 
 ZONE_SENSORS: tuple[InfinitudeSensorDescription, ...] = (
@@ -222,6 +246,18 @@ class InfinitudeSensorEntity(InfinitudeEntity, SensorEntity):
         """Set up the instance."""
         self.entity_description = entity_description
         super().__init__(coordinator, zone_id)
+
+    @property
+    def unique_id(self) -> str:
+        """Return the unique id.
+
+        Translated sensors key on the stable description key rather than the
+        base class's name, which would otherwise vary with the display language.
+        """
+        if self.entity_description.translation_key:
+            scope = f"zone_{self.zone.id}" if self.zone else "system"
+            return f"{self._id_base}_{scope}_{self.entity_description.key}"
+        return super().unique_id
 
     @property
     def native_value(self) -> StateType:

--- a/custom_components/infinitude_beyond/services.yaml
+++ b/custom_components/infinitude_beyond/services.yaml
@@ -32,3 +32,23 @@ set_hold_mode:
             - "manual"
       description: "Name of the activity profile to hold with.  If not provided, defaults to the current activity."
       example: "'home', 'away', 'sleep', 'wake', 'manual'"
+
+set_heat_source:
+  description: Sets the heat source for a dual-fuel Infinitude system
+  target:
+    entity:
+      integration: infinitude_beyond
+      domain: climate
+  fields:
+    heat_source:
+      selector:
+        select:
+          options:
+            - label: "System"
+              value: "system"
+            - label: "Gas"
+              value: "gas"
+            - label: "Heat Pump"
+              value: "heat_pump"
+      description: "Heat source to use: 'system' lets the system decide, 'gas' forces the furnace, 'heat_pump' forces the heat pump."
+      example: "'system', 'gas', 'heat_pump'"

--- a/custom_components/infinitude_beyond/strings.json
+++ b/custom_components/infinitude_beyond/strings.json
@@ -16,6 +16,45 @@
           }
         }
       }
+    },
+    "sensor": {
+      "furnace_status": {
+        "name": "Furnace status",
+        "state": {
+          "off": "Off",
+          "stage_1": "Stage 1",
+          "stage_2": "Stage 2",
+          "stage_3": "Stage 3",
+          "stage_4": "Stage 4",
+          "stage_5": "Stage 5",
+          "defrost": "Defrost",
+          "dehumidify": "Dehumidify"
+        }
+      },
+      "heatpump_status": {
+        "name": "Heat pump status",
+        "state": {
+          "off": "Off",
+          "stage_1": "Stage 1",
+          "stage_2": "Stage 2",
+          "stage_3": "Stage 3",
+          "stage_4": "Stage 4",
+          "stage_5": "Stage 5",
+          "defrost": "Defrost",
+          "dehumidify": "Dehumidify"
+        }
+      },
+      "heatpump_mode": {
+        "name": "Heat pump mode"
+      },
+      "heat_source": {
+        "name": "Heat source",
+        "state": {
+          "system": "System",
+          "gas": "Gas",
+          "heat_pump": "Heat Pump"
+        }
+      }
     }
   },
   "config": {

--- a/custom_components/infinitude_beyond/translations/en.json
+++ b/custom_components/infinitude_beyond/translations/en.json
@@ -16,6 +16,45 @@
           }
         }
       }
+    },
+    "sensor": {
+      "furnace_status": {
+        "name": "Furnace status",
+        "state": {
+          "off": "Off",
+          "stage_1": "Stage 1",
+          "stage_2": "Stage 2",
+          "stage_3": "Stage 3",
+          "stage_4": "Stage 4",
+          "stage_5": "Stage 5",
+          "defrost": "Defrost",
+          "dehumidify": "Dehumidify"
+        }
+      },
+      "heatpump_status": {
+        "name": "Heat pump status",
+        "state": {
+          "off": "Off",
+          "stage_1": "Stage 1",
+          "stage_2": "Stage 2",
+          "stage_3": "Stage 3",
+          "stage_4": "Stage 4",
+          "stage_5": "Stage 5",
+          "defrost": "Defrost",
+          "dehumidify": "Dehumidify"
+        }
+      },
+      "heatpump_mode": {
+        "name": "Heat pump mode"
+      },
+      "heat_source": {
+        "name": "Heat source",
+        "state": {
+          "system": "System",
+          "gas": "Gas",
+          "heat_pump": "Heat Pump"
+        }
+      }
     }
   },
   "config": {

--- a/tests/ha/test_climate.py
+++ b/tests/ha/test_climate.py
@@ -17,6 +17,7 @@ from custom_components.infinitude_beyond.const import (
 )
 from custom_components.infinitude_beyond.infinitude.const import (
     Activity,
+    HeatSource,
     HoldMode,
 )
 
@@ -69,3 +70,10 @@ async def test_set_preset_mode_legacy_hold_until():
     zone.set_hold_mode.assert_awaited_once_with(
         mode=HoldMode.UNTIL, activity=Activity.MANUAL
     )
+
+
+async def test_set_heat_source_maps_slug_to_enum():
+    entity, _zone = _make_entity()
+    entity.system.set_heat_source = AsyncMock()
+    await entity.async_set_heat_source("heat_pump")
+    entity.system.set_heat_source.assert_awaited_once_with(HeatSource.HEATPUMP)

--- a/tests/ha/test_sensor.py
+++ b/tests/ha/test_sensor.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from homeassistant.helpers import entity_registry as er
+
 
 async def test_modulation_sensors_only_register_when_reported(
     hass, mock_infinitude, config_entry
@@ -20,3 +22,27 @@ async def test_modulation_sensors_only_register_when_reported(
     assert any(n.endswith("IDU modulation") for n in names)
     assert any(n.endswith("Airflow") for n in names)
     assert not any(n.endswith("ODU modulation") for n in names)
+
+
+async def test_status_sensors_gate_and_use_key_based_ids(
+    hass, mock_infinitude, config_entry
+):
+    # The fixture reports an IDU (furnace status) but no ODU and no heat source.
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    names = {s.attributes.get("friendly_name", "") for s in hass.states.async_all("sensor")}
+    assert any(n.endswith("Furnace status") for n in names)
+    assert not any(n.endswith("Heat pump status") for n in names)
+    assert not any(n.endswith("Heat pump mode") for n in names)
+    assert not any(n.endswith("Heat source") for n in names)
+
+    # Translated sensors key on the description key, not the localized name.
+    reg = er.async_get(hass)
+    furnace = next(
+        e
+        for e in er.async_entries_for_config_entry(reg, config_entry.entry_id)
+        if e.translation_key == "furnace_status"
+    )
+    assert furnace.unique_id == f"{config_entry.entry_id}_system_furnace_status"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -20,6 +20,7 @@ import pytest
 from infinitude.const import (
     Activity,
     FanMode,
+    HeatSource,
     HoldMode,
     HoldState,
     HVACMode,
@@ -95,6 +96,43 @@ async def test_odu_modulation(infinitude):
     # A unit type we don't read modulation from reports nothing.
     infinitude._status["odu"] = {"type": "ac2stg", "opstat": "60"}
     assert infinitude.system.odu_modulation is None
+
+
+async def test_equipment_status_slugs(infinitude):
+    # Known staging values map to slugs; opmode passes through.
+    infinitude._status["idu"] = {"opstat": "Stage 1"}
+    infinitude._status["odu"] = {"opstat": "Stage 3", "opmode": "heating"}
+    assert infinitude.system.furnace_status == "stage_1"
+    assert infinitude.system.heatpump_status == "stage_3"
+    assert infinitude.system.heatpump_mode == "heating"
+
+
+async def test_equipment_status_passthrough_and_absent(infinitude):
+    # A value we didn't account for is passed through verbatim.
+    infinitude._status["odu"] = {"opstat": "Turbo"}
+    assert infinitude.system.heatpump_status == "Turbo"
+    # No odu block -> nothing to report (sensor won't register).
+    infinitude._status.pop("odu", None)
+    assert infinitude.system.heatpump_status is None
+    assert infinitude.system.heatpump_mode is None
+
+
+async def test_heat_source_mapping(infinitude):
+    for cfg, slug in (("system", "system"), ("idu only", "gas"), ("odu only", "heat_pump")):
+        infinitude._config["heatsource"] = cfg
+        assert infinitude.system.heat_source == slug
+    # Unrecognized or missing config -> None (controlled set, no passthrough).
+    infinitude._config["heatsource"] = "mystery"
+    assert infinitude.system.heat_source is None
+    infinitude._config.pop("heatsource", None)
+    assert infinitude.system.heat_source is None
+
+
+async def test_set_heat_source_posts_config(infinitude):
+    await infinitude.system.set_heat_source(HeatSource.HEATPUMP)
+    posts = [p for p in infinitude.posts if p["path"] == "/api/config"]
+    assert posts, "expected a POST to /api/config"
+    assert posts[-1]["data"] == {"heatsource": "odu only"}
 
 
 async def test_zone_temperatures(infinitude):


### PR DESCRIPTION
Reimplements #9 (thanks @kdjordjev) cleanly on `next` and closes #31.

- `set_heat_source` service (System / Gas / Heat Pump) for dual-fuel systems.
- Sensors: furnace status, heat pump status (the ODU stage #31 asked for), heat pump mode, heat source — gated so they only appear on equipment that reports them.
- Known status values map to translatable slugs; unaccounted-for values pass through raw. The translated sensors use a key-based unique_id so it doesn't shift with the display language.

Supersedes #9. The heat-source write path is contributor-verified on real dual-fuel hardware (not exercisable on a fancoil-only setup).

Closes #31.