### PR TITLE
Add a per-zone humidity sensor (#28)

### DIFF
--- a/custom_components/infinitude_beyond/sensor.py
+++ b/custom_components/infinitude_beyond/sensor.py
@@ -8,6 +8,7 @@ from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntity,
     SensorEntityDescription,
+    SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory, UnitOfTemperature
@@ -207,6 +208,15 @@ ZONE_SENSORS: tuple[InfinitudeSensorDescription, ...] = (
         key="occupancy",
         name="Occupancy",
         value_fn=lambda entity: entity.zone.occupancy,
+    ),
+    InfinitudeSensorDescription(
+        key="humidity_current",
+        name="Humidity",
+        device_class=SensorDeviceClass.HUMIDITY,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement="%",
+        value_fn=lambda entity: entity.zone.humidity_current,
+        exists_fn=lambda entity: entity.zone.humidity_current is not None,
     ),
 )
 

--- a/tests/ha/test_sensor.py
+++ b/tests/ha/test_sensor.py
@@ -46,3 +46,19 @@ async def test_status_sensors_gate_and_use_key_based_ids(
         if e.translation_key == "furnace_status"
     )
     assert furnace.unique_id == f"{config_entry.entry_id}_system_furnace_status"
+
+
+async def test_humidity_sensor_per_enabled_zone(hass, mock_infinitude, config_entry):
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    humidity = [
+        s
+        for s in hass.states.async_all("sensor")
+        if s.attributes.get("device_class") == "humidity"
+    ]
+    # Fixture enables zones 1 and 2, both reporting rh 42.
+    assert len(humidity) == 2
+    assert all(s.state == "42" for s in humidity)
+    assert all(s.attributes.get("unit_of_measurement") == "%" for s in humidity)


### PR DESCRIPTION
Exposes each zone's relative humidity as a Humidity sensor (humidity device class, %, measurement state class) so it can be graphed and used in automations without templating the climate `current_humidity` attribute. Only registers when the zone reports it.

Closes #28.