### PR TITLE
Show vacation status (#46, phase 1)

### DIFF
--- a/custom_components/infinitude_beyond/climate.py
+++ b/custom_components/infinitude_beyond/climate.py
@@ -30,6 +30,7 @@ from .const import (
     PRESET_HOLD,
     PRESET_HOLD_UNTIL,
     PRESET_SCHEDULE,
+    PRESET_VACATION,
     PRESET_WAKE,
 )
 from .infinitude.const import (
@@ -293,6 +294,10 @@ class InfinitudeClimate(InfinitudeEntity, ClimateEntity):
     @property
     def preset_mode(self):
         """Return current preset mode."""
+        # A running system vacation drives the zone regardless of hold state.
+        # Display-only: PRESET_VACATION is intentionally absent from preset_modes.
+        if self.zone.activity_current == InfActivity.VACATION:
+            return PRESET_VACATION
         # If hold is off, preset should reflect the effective current activity when available.
         # This avoids showing "Scheduled activity" (graph) or an out-of-date scheduled activity
         # when Infinitude reports a different currentActivity.

--- a/custom_components/infinitude_beyond/const.py
+++ b/custom_components/infinitude_beyond/const.py
@@ -8,6 +8,9 @@ PRESET_SCHEDULE = "schedule"
 PRESET_WAKE = "wake"
 PRESET_HOLD = "hold"
 PRESET_HOLD_UNTIL = "hold_until"
+# Display-only: reported when a zone is under a system vacation, never offered
+# in preset_modes (vacation is controlled elsewhere).
+PRESET_VACATION = "vacation"
 
 # Map the old human-readable preset values to the new slugs so automations
 # calling climate.set_preset_mode with the previous names keep working.

--- a/custom_components/infinitude_beyond/infinitude/api.py
+++ b/custom_components/infinitude_beyond/infinitude/api.py
@@ -625,6 +625,37 @@ class InfinitudeSystem:
         else:
             return None
 
+    def _vacation_datetime(self, value) -> datetime | None:
+        """Parse a vacation window timestamp, tolerating single-digit fields."""
+        if not isinstance(value, str):
+            return None
+        matches = match(r"^(\d{4})-(\d{1,2})-(\d{1,2})T(\d{2}):(\d{2}):(\d{2})", value)
+        if not matches:
+            return None
+        try:
+            return datetime(
+                *(int(g) for g in matches.groups()), tzinfo=self.local_timezone
+            )
+        except ValueError:
+            return None
+
+    @property
+    def vacation_state(self) -> str:
+        """Derived vacation state: disabled, scheduled, active, or ended."""
+        if str(self._config.get("vacat", "off")).lower() != "on":
+            return "disabled"
+        zones = self._infinitude.zones or {}
+        if any(z.activity_current == Activity.VACATION for z in zones.values()):
+            return "active"
+        now = self.local_time
+        start = self._vacation_datetime(self._config.get("vacstart"))
+        end = self._vacation_datetime(self._config.get("vacend"))
+        if now and start and now < start:
+            return "scheduled"
+        if now and end and now >= end:
+            return "ended"
+        return "active"
+
 
 class InfinitudeZone:
     """Representation of zone-specific Infinitude data."""

--- a/custom_components/infinitude_beyond/infinitude/const.py
+++ b/custom_components/infinitude_beyond/infinitude/const.py
@@ -40,6 +40,7 @@ class Activity(Enum):
     SLEEP = "sleep"
     WAKE = "wake"
     MANUAL = "manual"
+    VACATION = "vacation"
 
 
 class ActivityIndex(IntEnum):

--- a/custom_components/infinitude_beyond/sensor.py
+++ b/custom_components/infinitude_beyond/sensor.py
@@ -145,6 +145,11 @@ SYSTEM_SENSORS: tuple[InfinitudeSensorDescription, ...] = (
         value_fn=lambda entity: entity.system.heat_source,
         exists_fn=lambda entity: entity.system.heat_source is not None,
     ),
+    InfinitudeSensorDescription(
+        key="vacation",
+        translation_key="vacation",
+        value_fn=lambda entity: entity.system.vacation_state,
+    ),
 )
 
 ZONE_SENSORS: tuple[InfinitudeSensorDescription, ...] = (

--- a/custom_components/infinitude_beyond/strings.json
+++ b/custom_components/infinitude_beyond/strings.json
@@ -11,13 +11,23 @@
               "sleep": "Sleep",
               "wake": "Wake",
               "hold": "Hold indefinitely",
-              "hold_until": "Hold until next activity"
+              "hold_until": "Hold until next activity",
+              "vacation": "Vacation"
             }
           }
         }
       }
     },
     "sensor": {
+      "vacation": {
+        "name": "Vacation",
+        "state": {
+          "disabled": "Disabled",
+          "scheduled": "Scheduled",
+          "active": "Active",
+          "ended": "Ended"
+        }
+      },
       "furnace_status": {
         "name": "Furnace status",
         "state": {

--- a/custom_components/infinitude_beyond/translations/en.json
+++ b/custom_components/infinitude_beyond/translations/en.json
@@ -11,13 +11,23 @@
               "sleep": "Sleep",
               "wake": "Wake",
               "hold": "Hold indefinitely",
-              "hold_until": "Hold until next activity"
+              "hold_until": "Hold until next activity",
+              "vacation": "Vacation"
             }
           }
         }
       }
     },
     "sensor": {
+      "vacation": {
+        "name": "Vacation",
+        "state": {
+          "disabled": "Disabled",
+          "scheduled": "Scheduled",
+          "active": "Active",
+          "ended": "Ended"
+        }
+      },
       "furnace_status": {
         "name": "Furnace status",
         "state": {

--- a/tests/ha/test_climate.py
+++ b/tests/ha/test_climate.py
@@ -77,3 +77,12 @@ async def test_set_heat_source_maps_slug_to_enum():
     entity.system.set_heat_source = AsyncMock()
     await entity.async_set_heat_source("heat_pump")
     entity.system.set_heat_source.assert_awaited_once_with(HeatSource.HEATPUMP)
+
+
+async def test_preset_mode_reports_vacation_but_not_selectable():
+    entity, zone = _make_entity()
+    zone.activity_current = Activity.VACATION
+    # Displayed as the current preset...
+    assert entity.preset_mode == "vacation"
+    # ...but never offered as a selectable option (control lives elsewhere).
+    assert "vacation" not in entity.preset_modes

--- a/tests/ha/test_sensor.py
+++ b/tests/ha/test_sensor.py
@@ -62,3 +62,25 @@ async def test_humidity_sensor_per_enabled_zone(hass, mock_infinitude, config_en
     assert len(humidity) == 2
     assert all(s.state == "42" for s in humidity)
     assert all(s.attributes.get("unit_of_measurement") == "%" for s in humidity)
+
+
+async def test_vacation_sensor_registers_and_reports_state(
+    hass, mock_infinitude, config_entry
+):
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    reg = er.async_get(hass)
+    vac = next(
+        (
+            e
+            for e in er.async_entries_for_config_entry(reg, config_entry.entry_id)
+            if e.translation_key == "vacation"
+        ),
+        None,
+    )
+    assert vac is not None
+    assert vac.unique_id == f"{config_entry.entry_id}_system_vacation"
+    # Fixture has vacat off -> disabled.
+    assert hass.states.get(vac.entity_id).state == "disabled"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -135,6 +135,51 @@ async def test_set_heat_source_posts_config(infinitude):
     assert posts[-1]["data"] == {"heatsource": "odu only"}
 
 
+async def test_activity_current_recognizes_vacation(infinitude):
+    zstatus = next(z for z in infinitude._status["zones"]["zone"] if z["id"] == "1")
+    zstatus["currentActivity"] = "vacation"
+    assert infinitude.zones["1"].activity_current is Activity.VACATION
+
+
+async def test_vacation_state_disabled_when_off(infinitude):
+    assert infinitude.system.vacation_state == "disabled"
+
+
+async def test_vacation_state_from_window(infinitude):
+    # Fixture clock is 2024-01-15 08:00 (-05:00).
+    cfg = infinitude._config
+    cfg["vacat"] = "on"
+    cfg["vacstart"], cfg["vacend"] = (
+        "2024-01-01T00:00:00-05:00",
+        "2024-02-01T00:00:00-05:00",
+    )
+    assert infinitude.system.vacation_state == "active"
+    cfg["vacstart"], cfg["vacend"] = (
+        "2024-06-01T00:00:00-05:00",
+        "2024-07-01T00:00:00-05:00",
+    )
+    assert infinitude.system.vacation_state == "scheduled"
+    cfg["vacstart"], cfg["vacend"] = (
+        "2023-06-01T00:00:00-05:00",
+        "2023-07-01T00:00:00-05:00",
+    )
+    assert infinitude.system.vacation_state == "ended"
+
+
+async def test_vacation_state_active_via_zone_beats_stale_window(infinitude):
+    # A zone reporting the vacation activity means active even if the stored
+    # window looks past.
+    cfg = infinitude._config
+    cfg["vacat"] = "on"
+    cfg["vacstart"], cfg["vacend"] = (
+        "2023-01-01T00:00:00-05:00",
+        "2023-02-01T00:00:00-05:00",
+    )
+    zstatus = next(z for z in infinitude._status["zones"]["zone"] if z["id"] == "1")
+    zstatus["currentActivity"] = "vacation"
+    assert infinitude.system.vacation_state == "active"
+
+
 async def test_zone_temperatures(infinitude):
     zone = infinitude.zones["1"]
     assert zone.temperature_current == 70.0


### PR DESCRIPTION
Phase 1 of vacation support (#46) — read-only.

Recognizes the system vacation activity so a zone under a running vacation reports the **Vacation** preset instead of falling back to "Wake"/"Scheduled" (the reporter's actual complaint). Adds a system `sensor.vacation` reporting the derived state: disabled / scheduled / active / ended (computed from `vacat` + the window, with a zone reporting the vacation activity overriding a stale window; lenient parsing for the odd `2012-01-1T…` datetime format).

Vacation is display-only on the zone preset — reported as the current value but not offered in `preset_modes`, so HA won't let you select it. Control (turning vacation on/off, dates, setpoints, fan) comes in phase 2 as a system-scoped vacation climate entity + datetime helpers + services.

Part of #46 (not closing until phase 2 lands the control side).