### PR TITLE
Add vacation control (#46, phase 2)

### DIFF
--- a/custom_components/infinitude_beyond/__init__.py
+++ b/custom_components/infinitude_beyond/__init__.py
@@ -20,7 +20,12 @@ from homeassistant.helpers.update_coordinator import (
 from .const import DOMAIN
 from .infinitude.api import Infinitude
 
-PLATFORMS: list[Platform] = [Platform.CLIMATE, Platform.SENSOR, Platform.BINARY_SENSOR]
+PLATFORMS: list[Platform] = [
+    Platform.CLIMATE,
+    Platform.SENSOR,
+    Platform.BINARY_SENSOR,
+    Platform.DATETIME,
+]
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/infinitude_beyond/climate.py
+++ b/custom_components/infinitude_beyond/climate.py
@@ -309,6 +309,7 @@ class InfinitudeClimate(InfinitudeEntity, ClimateEntity):
             PRESET_WAKE,
             PRESET_HOLD,
             PRESET_HOLD_UNTIL,
+            PRESET_VACATION,
         ]
         return modes
 
@@ -318,7 +319,6 @@ class InfinitudeClimate(InfinitudeEntity, ClimateEntity):
         # A running system vacation drives the zone regardless of hold state.
         # Keyed on the config-derived state so it reflects immediately, rather
         # than waiting for the thermostat to report currentActivity=vacation.
-        # Display-only: PRESET_VACATION is intentionally absent from preset_modes.
         if self.system.vacation_active:
             return PRESET_VACATION
         # If hold is off, preset should reflect the effective current activity when available.
@@ -359,7 +359,10 @@ class InfinitudeClimate(InfinitudeEntity, ClimateEntity):
         _LOGGER.debug("Set preset mode: %s", preset_mode)
         # Accept the pre-slug preset names so older automations keep working.
         preset_mode = LEGACY_PRESET_ALIASES.get(preset_mode, preset_mode)
-        # Picking any zone preset while a system vacation is on ends the
+        if preset_mode == PRESET_VACATION:
+            await self.system.set_vacation(enabled=True)
+            return
+        # Picking any other preset while a system vacation is on ends the
         # vacation first, so the choice takes effect instead of being overridden.
         if self.system.vacation_enabled:
             await self.system.set_vacation(enabled=False)

--- a/custom_components/infinitude_beyond/climate.py
+++ b/custom_components/infinitude_beyond/climate.py
@@ -5,6 +5,8 @@ from datetime import timedelta
 
 import voluptuous as vol
 from homeassistant.components.climate import (
+    ATTR_TARGET_TEMP_HIGH,
+    ATTR_TARGET_TEMP_LOW,
     FAN_AUTO,
     FAN_HIGH,
     FAN_LOW,
@@ -52,6 +54,8 @@ ATTR_HOLD_UNTIL = "until"
 SERVICE_SET_HOLD_MODE = "set_hold_mode"
 ATTR_HEAT_SOURCE = "heat_source"
 SERVICE_SET_HEAT_SOURCE = "set_heat_source"
+SERVICE_SET_VACATION = "set_vacation"
+SERVICE_CLEAR_VACATION = "clear_vacation"
 
 
 async def async_setup_entry(
@@ -61,7 +65,7 @@ async def async_setup_entry(
 ) -> None:
     """Set up Infinitude climates from config entry."""
     coordinator = hass.data[DOMAIN][config_entry.entry_id]
-    entities = []
+    entities = [InfinitudeVacationClimate(coordinator)]
     zones = [z for z in coordinator.infinitude.zones.values() if z.enabled]
     for zone in zones:
         entities.extend([InfinitudeClimate(coordinator, zone.id)])
@@ -92,6 +96,23 @@ async def async_setup_entry(
         SERVICE_SET_HEAT_SOURCE,
         {vol.Required(ATTR_HEAT_SOURCE): vol.In([hs.value for hs in InfHeatSource])},
         "async_set_heat_source",
+    )
+
+    platform.async_register_entity_service(
+        SERVICE_SET_VACATION,
+        {
+            vol.Optional("enabled"): cv.boolean,
+            vol.Optional("start"): cv.datetime,
+            vol.Optional("end"): cv.datetime,
+            vol.Optional("heat"): vol.Coerce(float),
+            vol.Optional("cool"): vol.Coerce(float),
+            vol.Optional("fan"): vol.In([f.value for f in InfFanMode]),
+        },
+        "async_set_vacation",
+    )
+
+    platform.async_register_entity_service(
+        SERVICE_CLEAR_VACATION, {}, "async_clear_vacation"
     )
 
 
@@ -336,6 +357,10 @@ class InfinitudeClimate(InfinitudeEntity, ClimateEntity):
         _LOGGER.debug("Set preset mode: %s", preset_mode)
         # Accept the pre-slug preset names so older automations keep working.
         preset_mode = LEGACY_PRESET_ALIASES.get(preset_mode, preset_mode)
+        # Picking any zone preset while a system vacation is on ends the
+        # vacation first, so the choice takes effect instead of being overridden.
+        if self.system.vacation_enabled:
+            await self.system.set_vacation(enabled=False)
         if preset_mode == PRESET_SCHEDULE:
             # Remove all holds to restore the normal schedule
             await self.zone.set_hold_mode(mode=InfHoldMode.OFF)
@@ -390,3 +415,92 @@ class InfinitudeClimate(InfinitudeEntity, ClimateEntity):
         """Set the heat source for a dual-fuel system."""
         source = next((hs for hs in InfHeatSource if hs.value == heat_source), None)
         await self.system.set_heat_source(source)
+
+
+class InfinitudeVacationClimate(InfinitudeEntity, ClimateEntity):
+    """System-wide vacation, modeled as a thermostat on the system device."""
+
+    _attr_name = "Vacation"
+    _attr_hvac_modes = [HVACMode.OFF, HVACMode.HEAT_COOL]
+    _attr_supported_features = (
+        ClimateEntityFeature.TARGET_TEMPERATURE_RANGE | ClimateEntityFeature.FAN_MODE
+    )
+    _attr_fan_modes = [FAN_AUTO, FAN_LOW, FAN_MEDIUM, FAN_HIGH]
+    _attr_precision = PRECISION_WHOLE
+    _attr_temperature_step = PRECISION_WHOLE
+    _enable_turn_on_off_backwards_compatibility = False
+
+    _FAN_TO_HA = {
+        InfFanMode.AUTO: FAN_AUTO,
+        InfFanMode.HIGH: FAN_HIGH,
+        InfFanMode.MEDIUM: FAN_MEDIUM,
+        InfFanMode.LOW: FAN_LOW,
+    }
+    _HA_TO_FAN = {v: k for k, v in _FAN_TO_HA.items()}
+
+    @property
+    def temperature_unit(self) -> str:
+        """Return the unit of measurement."""
+        if self.system.temperature_unit == InfTemperatureUnit.CELSIUS:
+            return UnitOfTemperature.CELSIUS
+        return UnitOfTemperature.FAHRENHEIT
+
+    @property
+    def current_temperature(self):
+        """Vacation is system-wide; there's no single current temperature."""
+        return None
+
+    @property
+    def hvac_mode(self):
+        """HEAT_COOL when vacation is enabled, OFF otherwise."""
+        return HVACMode.HEAT_COOL if self.system.vacation_enabled else HVACMode.OFF
+
+    @property
+    def target_temperature_low(self):
+        """Vacation heat setpoint."""
+        return self.system.vacation_heat
+
+    @property
+    def target_temperature_high(self):
+        """Vacation cool setpoint."""
+        return self.system.vacation_cool
+
+    @property
+    def fan_mode(self):
+        """Vacation fan mode."""
+        return self._FAN_TO_HA.get(self.system.vacation_fan, FAN_AUTO)
+
+    async def async_set_hvac_mode(self, hvac_mode):
+        """Enable vacation for HEAT_COOL, disable for OFF."""
+        await self.system.set_vacation(enabled=hvac_mode == HVACMode.HEAT_COOL)
+
+    async def async_set_temperature(self, **kwargs):
+        """Set the vacation heat/cool setpoints."""
+        await self.system.set_vacation(
+            heat=kwargs.get(ATTR_TARGET_TEMP_LOW),
+            cool=kwargs.get(ATTR_TARGET_TEMP_HIGH),
+        )
+
+    async def async_set_fan_mode(self, fan_mode):
+        """Set the vacation fan mode."""
+        await self.system.set_vacation(
+            fan=self._HA_TO_FAN.get(fan_mode, InfFanMode.AUTO)
+        )
+
+    async def async_set_vacation(
+        self, enabled=None, start=None, end=None, heat=None, cool=None, fan=None
+    ):
+        """Service: set any subset of the vacation config in one request."""
+        fan_mode = next((f for f in InfFanMode if f.value == fan), None) if fan else None
+        await self.system.set_vacation(
+            enabled=enabled,
+            start=start,
+            end=end,
+            heat=heat,
+            cool=cool,
+            fan=fan_mode,
+        )
+
+    async def async_clear_vacation(self):
+        """Service: disable vacation."""
+        await self.system.set_vacation(enabled=False)

--- a/custom_components/infinitude_beyond/climate.py
+++ b/custom_components/infinitude_beyond/climate.py
@@ -316,8 +316,10 @@ class InfinitudeClimate(InfinitudeEntity, ClimateEntity):
     def preset_mode(self):
         """Return current preset mode."""
         # A running system vacation drives the zone regardless of hold state.
+        # Keyed on the config-derived state so it reflects immediately, rather
+        # than waiting for the thermostat to report currentActivity=vacation.
         # Display-only: PRESET_VACATION is intentionally absent from preset_modes.
-        if self.zone.activity_current == InfActivity.VACATION:
+        if self.system.vacation_active:
             return PRESET_VACATION
         # If hold is off, preset should reflect the effective current activity when available.
         # This avoids showing "Scheduled activity" (graph) or an out-of-date scheduled activity

--- a/custom_components/infinitude_beyond/datetime.py
+++ b/custom_components/infinitude_beyond/datetime.py
@@ -1,0 +1,83 @@
+"""Datetime entities for Infinitude (the vacation window)."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from datetime import datetime
+
+from homeassistant.components.datetime import (
+    DateTimeEntity,
+    DateTimeEntityDescription,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import InfinitudeDataUpdateCoordinator, InfinitudeEntity
+from .const import DOMAIN
+
+
+@dataclass(frozen=True, kw_only=True)
+class InfinitudeDateTimeDescription(DateTimeEntityDescription):
+    """Describes an Infinitude datetime entity."""
+
+    value_fn: Callable[[InfinitudeEntity], datetime | None]
+    set_fn: Callable[[InfinitudeEntity, datetime], Awaitable[None]]
+
+
+DATETIMES: tuple[InfinitudeDateTimeDescription, ...] = (
+    InfinitudeDateTimeDescription(
+        key="vacation_start",
+        translation_key="vacation_start",
+        value_fn=lambda entity: entity.system.vacation_start,
+        set_fn=lambda entity, value: entity.system.set_vacation(start=value),
+    ),
+    InfinitudeDateTimeDescription(
+        key="vacation_end",
+        translation_key="vacation_end",
+        value_fn=lambda entity: entity.system.vacation_end,
+        set_fn=lambda entity, value: entity.system.set_vacation(end=value),
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Infinitude datetime entities from config entry."""
+    coordinator = hass.data[DOMAIN][config_entry.entry_id]
+    async_add_entities(
+        InfinitudeDateTimeEntity(coordinator, description) for description in DATETIMES
+    )
+
+
+class InfinitudeDateTimeEntity(InfinitudeEntity, DateTimeEntity):
+    """A configurable Infinitude datetime (system-scoped)."""
+
+    entity_description: InfinitudeDateTimeDescription
+
+    def __init__(
+        self,
+        coordinator: InfinitudeDataUpdateCoordinator,
+        entity_description: InfinitudeDateTimeDescription,
+    ) -> None:
+        """Set up the instance."""
+        self.entity_description = entity_description
+        super().__init__(coordinator)
+
+    @property
+    def unique_id(self) -> str:
+        """Key-based id (stable across display language)."""
+        return f"{self._id_base}_system_{self.entity_description.key}"
+
+    @property
+    def native_value(self) -> datetime | None:
+        """Return the current value."""
+        return self.entity_description.value_fn(self)
+
+    async def async_set_value(self, value: datetime) -> None:
+        """Write the new value."""
+        await self.entity_description.set_fn(self, value)

--- a/custom_components/infinitude_beyond/icons.json
+++ b/custom_components/infinitude_beyond/icons.json
@@ -8,7 +8,8 @@
               "schedule": "mdi:clock-outline",
               "wake": "mdi:alarm",
               "hold": "mdi:infinity",
-              "hold_until": "mdi:motion-pause-outline"
+              "hold_until": "mdi:motion-pause-outline",
+              "vacation": "mdi:calendar"
             }
           }
         }

--- a/custom_components/infinitude_beyond/infinitude/api.py
+++ b/custom_components/infinitude_beyond/infinitude/api.py
@@ -662,6 +662,11 @@ class InfinitudeSystem:
         return str(self._config.get("vacat", "off")).lower() == "on"
 
     @property
+    def vacation_active(self) -> bool:
+        """Whether vacation is currently in effect."""
+        return self.vacation_state == "active"
+
+    @property
     def vacation_start(self) -> datetime | None:
         """Configured vacation start."""
         return self._vacation_datetime(self._config.get("vacstart"))

--- a/custom_components/infinitude_beyond/infinitude/api.py
+++ b/custom_components/infinitude_beyond/infinitude/api.py
@@ -656,6 +656,93 @@ class InfinitudeSystem:
             return "ended"
         return "active"
 
+    @property
+    def vacation_enabled(self) -> bool:
+        """Whether vacation is enabled in config."""
+        return str(self._config.get("vacat", "off")).lower() == "on"
+
+    @property
+    def vacation_start(self) -> datetime | None:
+        """Configured vacation start."""
+        return self._vacation_datetime(self._config.get("vacstart"))
+
+    @property
+    def vacation_end(self) -> datetime | None:
+        """Configured vacation end."""
+        return self._vacation_datetime(self._config.get("vacend"))
+
+    @property
+    def vacation_heat(self) -> float | None:
+        """Vacation heat (minimum) setpoint."""
+        val = self._config.get("vacmint")
+        return float(val) if val not in (None, "") else None
+
+    @property
+    def vacation_cool(self) -> float | None:
+        """Vacation cool (maximum) setpoint."""
+        val = self._config.get("vacmaxt")
+        return float(val) if val not in (None, "") else None
+
+    @property
+    def vacation_fan(self) -> FanMode | None:
+        """Vacation fan mode."""
+        val = self._config.get("vacfan")
+        if not val:
+            return None
+        return next((f for f in FanMode if f.value == val), None)
+
+    async def set_vacation(
+        self,
+        *,
+        enabled: bool | None = None,
+        start: datetime | None = None,
+        end: datetime | None = None,
+        heat: int | None = None,
+        cool: int | None = None,
+        fan: FanMode | None = None,
+    ) -> None:
+        """Write vacation config in a single request.
+
+        When enabling without an explicit window (or with a stale/past one),
+        default to now .. now+7 days.
+        """
+        # Write local wall-clock: reads ignore the stored offset and apply the
+        # system timezone, so the written value must be in that same frame.
+        tz = self.local_timezone
+        if start is not None:
+            start = start.replace(tzinfo=tz) if start.tzinfo is None else start.astimezone(tz)
+        if end is not None:
+            end = end.replace(tzinfo=tz) if end.tzinfo is None else end.astimezone(tz)
+
+        data: dict = {}
+        if enabled is not None:
+            data["vacat"] = "on" if enabled else "off"
+        if start is not None:
+            data["vacstart"] = start.replace(microsecond=0).isoformat()
+        if end is not None:
+            data["vacend"] = end.replace(microsecond=0).isoformat()
+        if heat is not None:
+            data["vacmint"] = str(float(heat))
+        if cool is not None:
+            data["vacmaxt"] = str(float(cool))
+        if fan is not None:
+            data["vacfan"] = fan.value
+
+        if data.get("vacat") == "on" and start is None and end is None:
+            now = self.local_time
+            cur_start, cur_end = self.vacation_start, self.vacation_end
+            if not cur_start or not cur_end or (now and cur_end <= now):
+                base = (now or datetime.now(tz=self.local_timezone)).replace(
+                    minute=0, second=0, microsecond=0
+                )
+                data["vacstart"] = base.isoformat()
+                data["vacend"] = (base + timedelta(days=7)).isoformat()
+
+        if not data:
+            return
+        await self._infinitude._post("/api/config", data)
+        await self._infinitude.update()
+
 
 class InfinitudeZone:
     """Representation of zone-specific Infinitude data."""

--- a/custom_components/infinitude_beyond/services.yaml
+++ b/custom_components/infinitude_beyond/services.yaml
@@ -52,3 +52,53 @@ set_heat_source:
               value: "heat_pump"
       description: "Heat source to use: 'system' lets the system decide, 'gas' forces the furnace, 'heat_pump' forces the heat pump."
       example: "'system', 'gas', 'heat_pump'"
+
+set_vacation:
+  description: Configures the system vacation in a single request. Omitted fields are left unchanged; enabling without a window defaults to the next seven days.
+  target:
+    entity:
+      integration: infinitude_beyond
+      domain: climate
+  fields:
+    enabled:
+      selector:
+        boolean:
+      description: "Turn vacation on or off."
+    start:
+      selector:
+        datetime:
+      description: "Vacation start date and time."
+    end:
+      selector:
+        datetime:
+      description: "Vacation end date and time."
+    heat:
+      selector:
+        number:
+          min: 40
+          max: 90
+          mode: box
+      description: "Vacation heat (minimum) setpoint."
+    cool:
+      selector:
+        number:
+          min: 50
+          max: 99
+          mode: box
+      description: "Vacation cool (maximum) setpoint."
+    fan:
+      selector:
+        select:
+          options:
+            - "off"
+            - "low"
+            - "med"
+            - "high"
+      description: "Vacation fan setting."
+
+clear_vacation:
+  description: Turns off the system vacation.
+  target:
+    entity:
+      integration: infinitude_beyond
+      domain: climate

--- a/custom_components/infinitude_beyond/strings.json
+++ b/custom_components/infinitude_beyond/strings.json
@@ -18,6 +18,14 @@
         }
       }
     },
+    "datetime": {
+      "vacation_start": {
+        "name": "Vacation start"
+      },
+      "vacation_end": {
+        "name": "Vacation end"
+      }
+    },
     "sensor": {
       "vacation": {
         "name": "Vacation",

--- a/custom_components/infinitude_beyond/translations/en.json
+++ b/custom_components/infinitude_beyond/translations/en.json
@@ -18,6 +18,14 @@
         }
       }
     },
+    "datetime": {
+      "vacation_start": {
+        "name": "Vacation start"
+      },
+      "vacation_end": {
+        "name": "Vacation end"
+      }
+    },
     "sensor": {
       "vacation": {
         "name": "Vacation",

--- a/tests/ha/test_climate.py
+++ b/tests/ha/test_climate.py
@@ -8,7 +8,10 @@ from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from custom_components.infinitude_beyond.climate import InfinitudeClimate
+from custom_components.infinitude_beyond.climate import (
+    InfinitudeClimate,
+    InfinitudeVacationClimate,
+)
 from custom_components.infinitude_beyond.const import (
     PRESET_HOLD,
     PRESET_HOLD_UNTIL,
@@ -17,9 +20,11 @@ from custom_components.infinitude_beyond.const import (
 )
 from custom_components.infinitude_beyond.infinitude.const import (
     Activity,
+    FanMode,
     HeatSource,
     HoldMode,
 )
+from homeassistant.components.climate import HVACMode
 
 COMPONENT = Path(__file__).resolve().parents[2] / "custom_components" / "infinitude_beyond"
 CUSTOM_PRESETS = (PRESET_SCHEDULE, PRESET_WAKE, PRESET_HOLD, PRESET_HOLD_UNTIL)
@@ -31,7 +36,11 @@ def _make_entity():
     zone.set_hold_mode = AsyncMock()
     coordinator = MagicMock()
     coordinator.infinitude.zones = {"1": zone}
-    return InfinitudeClimate(coordinator, "1"), zone
+    entity = InfinitudeClimate(coordinator, "1")
+    # No vacation in play for these unit tests (skip the behavior-C branch).
+    entity.system.vacation_enabled = False
+    entity.system.set_vacation = AsyncMock()
+    return entity, zone
 
 
 def test_custom_presets_are_slugs():
@@ -86,3 +95,38 @@ async def test_preset_mode_reports_vacation_but_not_selectable():
     assert entity.preset_mode == "vacation"
     # ...but never offered as a selectable option (control lives elsewhere).
     assert "vacation" not in entity.preset_modes
+
+
+async def test_zone_preset_change_exits_vacation():
+    # Behavior C: picking a normal preset while vacation is on ends vacation.
+    entity, zone = _make_entity()
+    entity.system.vacation_enabled = True
+    await entity.async_set_preset_mode("home")
+    entity.system.set_vacation.assert_awaited_once_with(enabled=False)
+
+
+def _make_vacation_entity():
+    from unittest.mock import MagicMock
+
+    coordinator = MagicMock()
+    coordinator.infinitude.zones = {}
+    entity = InfinitudeVacationClimate(coordinator)
+    entity.system.set_vacation = AsyncMock()
+    return entity
+
+
+async def test_vacation_climate_hvac_mode_toggles_vacation():
+    entity = _make_vacation_entity()
+    await entity.async_set_hvac_mode(HVACMode.HEAT_COOL)
+    entity.system.set_vacation.assert_awaited_with(enabled=True)
+    await entity.async_set_hvac_mode(HVACMode.OFF)
+    entity.system.set_vacation.assert_awaited_with(enabled=False)
+
+
+async def test_vacation_climate_service_maps_fan_slug():
+    entity = _make_vacation_entity()
+    await entity.async_set_vacation(enabled=True, heat=60, cool=80, fan="low")
+    kwargs = entity.system.set_vacation.await_args.kwargs
+    assert kwargs["enabled"] is True
+    assert kwargs["heat"] == 60 and kwargs["cool"] == 80
+    assert kwargs["fan"] is FanMode.LOW

--- a/tests/ha/test_climate.py
+++ b/tests/ha/test_climate.py
@@ -37,8 +37,9 @@ def _make_entity():
     coordinator = MagicMock()
     coordinator.infinitude.zones = {"1": zone}
     entity = InfinitudeClimate(coordinator, "1")
-    # No vacation in play for these unit tests (skip the behavior-C branch).
+    # No vacation in play for these unit tests (skip behavior-C / vacation preset).
     entity.system.vacation_enabled = False
+    entity.system.vacation_active = False
     entity.system.set_vacation = AsyncMock()
     return entity, zone
 
@@ -89,8 +90,8 @@ async def test_set_heat_source_maps_slug_to_enum():
 
 
 async def test_preset_mode_reports_vacation_but_not_selectable():
-    entity, zone = _make_entity()
-    zone.activity_current = Activity.VACATION
+    entity, _zone = _make_entity()
+    entity.system.vacation_active = True
     # Displayed as the current preset...
     assert entity.preset_mode == "vacation"
     # ...but never offered as a selectable option (control lives elsewhere).

--- a/tests/ha/test_climate.py
+++ b/tests/ha/test_climate.py
@@ -89,13 +89,22 @@ async def test_set_heat_source_maps_slug_to_enum():
     entity.system.set_heat_source.assert_awaited_once_with(HeatSource.HEATPUMP)
 
 
-async def test_preset_mode_reports_vacation_but_not_selectable():
+async def test_preset_mode_reports_vacation():
     entity, _zone = _make_entity()
     entity.system.vacation_active = True
-    # Displayed as the current preset...
     assert entity.preset_mode == "vacation"
-    # ...but never offered as a selectable option (control lives elsewhere).
-    assert "vacation" not in entity.preset_modes
+
+
+def test_vacation_preset_is_offered_last():
+    entity, _zone = _make_entity()
+    assert "vacation" in entity.preset_modes
+    assert entity.preset_modes[-1] == "vacation"
+
+
+async def test_selecting_vacation_preset_enables_vacation():
+    entity, _zone = _make_entity()
+    await entity.async_set_preset_mode("vacation")
+    entity.system.set_vacation.assert_awaited_once_with(enabled=True)
 
 
 async def test_zone_preset_change_exits_vacation():

--- a/tests/ha/test_init.py
+++ b/tests/ha/test_init.py
@@ -20,14 +20,19 @@ async def test_setup_creates_climate_entities(hass, mock_infinitude, config_entr
 
     assert config_entry.state is ConfigEntryState.LOADED
 
-    # The fixture enables zones 1 and 2 only -> two climate entities.
-    climate_states = hass.states.async_all("climate")
-    assert len(climate_states) == 2
+    # The fixture enables zones 1 and 2 -> two zone thermostats (plus the
+    # system-wide Vacation climate, which has no current_temperature).
+    zone_states = [
+        s
+        for s in hass.states.async_all("climate")
+        if s.attributes.get("current_temperature") is not None
+    ]
+    assert len(zone_states) == 2
 
     # System is in heat mode; zone 1 current 70F, zone 2 current 68F.
-    states_by_temp = {s.attributes.get("current_temperature") for s in climate_states}
+    states_by_temp = {s.attributes.get("current_temperature") for s in zone_states}
     assert states_by_temp == {70.0, 68.0}
-    assert all(s.state == "heat" for s in climate_states)
+    assert all(s.state == "heat" for s in zone_states)
 
 
 async def test_climate_target_temperature_supported_in_any_mode(
@@ -37,7 +42,13 @@ async def test_climate_target_temperature_supported_in_any_mode(
     assert await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
-    feats = hass.states.async_all("climate")[0].attributes["supported_features"]
+    # Pick a zone thermostat (the vacation climate only supports a temp range).
+    zone = next(
+        s
+        for s in hass.states.async_all("climate")
+        if s.attributes.get("current_temperature") is not None
+    )
+    feats = zone.attributes["supported_features"]
     assert feats & ClimateEntityFeature.TARGET_TEMPERATURE
     assert feats & ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
 

--- a/tests/ha/test_vacation.py
+++ b/tests/ha/test_vacation.py
@@ -1,0 +1,36 @@
+"""Layer 2 — vacation control entities (#46 phase 2)."""
+
+from __future__ import annotations
+
+
+async def test_vacation_climate_registers_off_by_default(
+    hass, mock_infinitude, config_entry
+):
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    vac = next(
+        (
+            s
+            for s in hass.states.async_all("climate")
+            if s.attributes.get("friendly_name", "").endswith("Vacation")
+        ),
+        None,
+    )
+    assert vac is not None
+    # Fixture has vacat off.
+    assert vac.state == "off"
+    assert "heat_cool" in vac.attributes["hvac_modes"]
+
+
+async def test_vacation_datetime_entities_register(
+    hass, mock_infinitude, config_entry
+):
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    datetimes = {s.entity_id for s in hass.states.async_all("datetime")}
+    assert any(e.endswith("vacation_start") for e in datetimes)
+    assert any(e.endswith("vacation_end") for e in datetimes)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -180,6 +180,49 @@ async def test_vacation_state_active_via_zone_beats_stale_window(infinitude):
     assert infinitude.system.vacation_state == "active"
 
 
+def _last_config_post(infinitude):
+    return [p for p in infinitude.posts if p["path"] == "/api/config"][-1]["data"]
+
+
+async def test_set_vacation_enable_defaults_stale_window(infinitude):
+    # Stale placeholder window -> enabling installs a fresh one.
+    infinitude._config["vacstart"] = "2012-01-1T21:00:00-00:00"
+    infinitude._config["vacend"] = "2013-01-1T21:00:00-00:00"
+    await infinitude.system.set_vacation(enabled=True)
+    post = _last_config_post(infinitude)
+    assert post["vacat"] == "on"
+    assert "vacstart" in post and "vacend" in post
+
+
+async def test_set_vacation_keeps_valid_future_window(infinitude):
+    # A valid future window (fixture clock is 2024-01-15) is left untouched.
+    infinitude._config["vacstart"] = "2024-06-01T00:00:00-05:00"
+    infinitude._config["vacend"] = "2024-07-01T00:00:00-05:00"
+    await infinitude.system.set_vacation(enabled=True)
+    assert _last_config_post(infinitude) == {"vacat": "on"}
+
+
+async def test_set_vacation_writes_setpoints_and_fan(infinitude):
+    await infinitude.system.set_vacation(heat=60, cool=80, fan=FanMode.LOW)
+    assert _last_config_post(infinitude) == {
+        "vacmint": "60.0",
+        "vacmaxt": "80.0",
+        "vacfan": "low",
+    }
+
+
+async def test_vacation_setpoints_parse_float_strings(infinitude):
+    infinitude._config["vacmint"] = "60.0"
+    infinitude._config["vacmaxt"] = "90.0"
+    assert infinitude.system.vacation_heat == 60.0
+    assert infinitude.system.vacation_cool == 90.0
+
+
+async def test_set_vacation_disable(infinitude):
+    await infinitude.system.set_vacation(enabled=False)
+    assert _last_config_post(infinitude) == {"vacat": "off"}
+
+
 async def test_zone_temperatures(infinitude):
     zone = infinitude.zones["1"]
     assert zone.temperature_current == 70.0


### PR DESCRIPTION
Phase 2 of vacation support (#46) — the control side. Builds on the read/display work in #65.

- **System Vacation climate entity** — `OFF`/`HEAT_COOL`, heat/cool band (`vacmint`/`vacmaxt`), fan (`vacfan`), on the Infinitude System device.
- **`datetime.vacation_start` / `_end`** for the window (new datetime platform).
- **Services** `set_vacation` (atomic; all fields optional) and `clear_vacation`.
- **Vacation is a selectable zone preset** (last in the list, calendar icon): choosing it turns vacation on with default dates; choosing any other preset ends vacation first so the choice sticks. The zone preset also displays "Vacation" whenever vacation is active, driven by config state so it reflects immediately.
- Enabling with a stale/missing window defaults to the next seven days. Setpoints are read/written as floats (the thermostat stores e.g. `90.0`).

Validated on real hardware: enabling/among the vacation controls writes the config correctly and the zone preset reflects it.

Closes #46.