### PR TITLE
Handle the thermostat-not-reporting case

### DIFF
--- a/custom_components/infinitude_beyond/binary_sensor.py
+++ b/custom_components/infinitude_beyond/binary_sensor.py
@@ -103,12 +103,13 @@ class InfinitudeBinarySensorEntity(InfinitudeEntity, BinarySensorEntity):
 
 
 class InfinitudeConnectivityBinarySensorEntity(InfinitudeEntity, BinarySensorEntity):
-    """Reports whether Home Assistant can reach Infinitude.
+    """Reports whether live thermostat data is flowing.
 
-    This one stays available even when the connection is down -- a normal
-    coordinator entity goes unavailable the moment a fetch fails, which is
-    exactly when you'd want to read it. So it overrides availability and
-    reports the coordinator's last fetch result instead.
+    On means both links are healthy: Home Assistant reached Infinitude and
+    Infinitude is returning thermostat data. It reads "disconnected" when HA
+    can't reach Infinitude or when Infinitude is reachable but the thermostat
+    isn't reporting to it (empty status). Always available so it can actually
+    report the disconnected state.
     """
 
     _attr_name = "Connectivity"
@@ -122,5 +123,5 @@ class InfinitudeConnectivityBinarySensorEntity(InfinitudeEntity, BinarySensorEnt
 
     @property
     def is_on(self) -> bool:
-        """True while the last fetch from Infinitude succeeded."""
-        return self.coordinator.last_update_success
+        """True while HA reached Infinitude and the thermostat is reporting."""
+        return self.coordinator.last_update_success and self.system.connected

--- a/custom_components/infinitude_beyond/infinitude/api.py
+++ b/custom_components/infinitude_beyond/infinitude/api.py
@@ -345,6 +345,15 @@ class InfinitudeSystem:
         return self._infinitude._profile or {}
 
     @property
+    def connected(self) -> bool:
+        """Whether Infinitude is returning live thermostat data.
+
+        An empty status means Infinitude is reachable but the thermostat isn't
+        reporting to it.
+        """
+        return bool(self._status)
+
+    @property
     def brand(self) -> str | None:
         """Brand of the system."""
         val = self._profile.get("brand")

--- a/custom_components/infinitude_beyond/infinitude/api.py
+++ b/custom_components/infinitude_beyond/infinitude/api.py
@@ -327,22 +327,22 @@ class InfinitudeSystem:
     @property
     def _config(self) -> dict:
         """Raw Infinitude config data for the system."""
-        return self._infinitude._config
+        return self._infinitude._config or {}
 
     @property
     def _status(self) -> dict:
         """Raw Infinitude status data for the system."""
-        return self._infinitude._status
+        return self._infinitude._status or {}
 
     @property
     def _energy(self) -> dict:
         """Raw Infinitude energy data for the system."""
-        return self._infinitude._energy
+        return self._infinitude._energy or {}
 
     @property
     def _profile(self) -> dict:
         """Raw Infinitude profile data for the system."""
-        return self._infinitude._profile
+        return self._infinitude._profile or {}
 
     @property
     def brand(self) -> str | None:
@@ -673,7 +673,7 @@ class InfinitudeZone:
     @property
     def _config(self) -> dict:
         """Raw Infinitude config data for the zone."""
-        all_zones = self._infinitude._config.get("zones", {}).get("zone", [])
+        all_zones = (self._infinitude._config or {}).get("zones", {}).get("zone", [])
         zone_config = next(
             (zone for zone in all_zones if zone.get("id") == self.id), {}
         )
@@ -682,7 +682,7 @@ class InfinitudeZone:
     @property
     def _status(self) -> dict:
         """Raw Infinitude status data for the zone."""
-        all_zones = self._infinitude._status.get("zones", {}).get("zone", [])
+        all_zones = (self._infinitude._status or {}).get("zones", {}).get("zone", [])
         zone_status = next(
             (zone for zone in all_zones if zone.get("id") == self.id), {}
         )

--- a/tests/ha/test_binary_sensor.py
+++ b/tests/ha/test_binary_sensor.py
@@ -39,3 +39,22 @@ async def test_connectivity_sensor_tracks_coordinator_without_going_unavailable(
     await hass.async_block_till_done()
 
     assert hass.states.get(conn.entity_id).state == "on"
+
+
+async def test_connectivity_off_when_thermostat_not_reporting(
+    hass, mock_infinitude, config_entry
+):
+    # Infinitude is reachable but the thermostat isn't reporting (empty status).
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    conn = _connectivity_state(hass)
+    assert conn.state == "on"
+
+    coordinator = hass.data[DOMAIN][config_entry.entry_id]
+    coordinator.infinitude._status = None  # thermostat not connected to Infinitude
+    coordinator.async_update_listeners()
+    await hass.async_block_till_done()
+
+    assert hass.states.get(conn.entity_id).state == "off"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -128,6 +128,16 @@ async def test_heat_source_mapping(infinitude):
     assert infinitude.system.heat_source is None
 
 
+async def test_properties_tolerate_missing_payloads(infinitude):
+    # An empty /api/status (or config) must not crash the entities.
+    infinitude._status = None
+    infinitude._config = None
+    assert infinitude.system.humidifier_state is None
+    assert infinitude.system.temperature_outside is None
+    assert infinitude.system.vacation_state == "disabled"
+    assert infinitude.zones["1"].temperature_current is None
+
+
 async def test_set_heat_source_posts_config(infinitude):
     await infinitude.system.set_heat_source(HeatSource.HEATPUMP)
     posts = [p for p in infinitude.posts if p["path"] == "/api/config"]


### PR DESCRIPTION
Seen against a live system: when the thermostat isn't connected to Infinitude, `/api/status` comes back empty. Two problems fell out of that, both fixed here:

1. **Crash.** `_status` was `None`, so every system property threw `AttributeError: 'NoneType' object has no attribute 'get'`. The raw-data accessors now coalesce `None` → `{}`, so properties degrade to `None`/unavailable instead of crashing.

2. **Misleading connectivity.** The connectivity sensor only tracked HA↔Infinitude, so it read "connected" even though the thermostat was offline and there was no live data. It now means live data is flowing — on when HA reached Infinitude **and** the thermostat is reporting; off if either link is down (this still covers #29's original "can't reach Infinitude").

(The `_compare_data` "NoneType/float" debug lines in the same log are the separate, known #18 issue — debug noise, not a crash.)