### PR TITLE
Only create the occupancy sensor when reported

### DIFF
--- a/custom_components/infinitude_beyond/sensor.py
+++ b/custom_components/infinitude_beyond/sensor.py
@@ -213,6 +213,8 @@ ZONE_SENSORS: tuple[InfinitudeSensorDescription, ...] = (
         key="occupancy",
         name="Occupancy",
         value_fn=lambda entity: entity.zone.occupancy,
+        # Only zones with an occupancy sensor report this; skip the rest.
+        exists_fn=lambda entity: entity.zone.occupancy is not None,
     ),
     InfinitudeSensorDescription(
         key="humidity_current",

--- a/tests/ha/test_sensor.py
+++ b/tests/ha/test_sensor.py
@@ -2,7 +2,19 @@
 
 from __future__ import annotations
 
+from unittest.mock import MagicMock
+
+from custom_components.infinitude_beyond.sensor import ZONE_SENSORS
 from homeassistant.helpers import entity_registry as er
+
+
+def test_occupancy_sensor_gated_on_value():
+    desc = next(d for d in ZONE_SENSORS if d.key == "occupancy")
+    entity = MagicMock()
+    entity.zone.occupancy = None
+    assert desc.exists_fn(entity) is False
+    entity.zone.occupancy = "occupied"
+    assert desc.exists_fn(entity) is True
 
 
 async def test_modulation_sensors_only_register_when_reported(


### PR DESCRIPTION
The occupancy sensor was always created, so zones without an occupancy sensor got an entity permanently stuck at "unknown". Adds `exists_fn=lambda entity: entity.zone.occupancy is not None`, mirroring the humidity sensor — a create-time gate like the other conditional sensors.