### PR TITLE
Split connectivity into two sensors

### DIFF
--- a/custom_components/infinitude_beyond/binary_sensor.py
+++ b/custom_components/infinitude_beyond/binary_sensor.py
@@ -62,7 +62,10 @@ async def async_setup_entry(
 ) -> None:
     """Set up Infinitude binary sensors from config entry."""
     coordinator = hass.data[DOMAIN][config_entry.entry_id]
-    entities = [InfinitudeConnectivityBinarySensorEntity(coordinator)]
+    entities = [
+        InfinitudeConnectivityBinarySensorEntity(coordinator),
+        InfinitudeThermostatConnectivityBinarySensorEntity(coordinator),
+    ]
     for entity_description in SYSTEM_BINARY_SENSORS:
         entities.append(InfinitudeBinarySensorEntity(coordinator, entity_description))
     zones = [z for z in coordinator.infinitude.zones.values() if z.enabled]
@@ -102,17 +105,13 @@ class InfinitudeBinarySensorEntity(InfinitudeEntity, BinarySensorEntity):
         return None
 
 
-class InfinitudeConnectivityBinarySensorEntity(InfinitudeEntity, BinarySensorEntity):
-    """Reports whether live thermostat data is flowing.
+class _InfinitudeConnectivityBase(InfinitudeEntity, BinarySensorEntity):
+    """Shared bits for the connectivity sensors.
 
-    On means both links are healthy: Home Assistant reached Infinitude and
-    Infinitude is returning thermostat data. It reads "disconnected" when HA
-    can't reach Infinitude or when Infinitude is reachable but the thermostat
-    isn't reporting to it (empty status). Always available so it can actually
-    report the disconnected state.
+    Always available so they can actually report the disconnected state, which
+    a plain coordinator entity can't (it goes unavailable on a failed fetch).
     """
 
-    _attr_name = "Connectivity"
     _attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
     _attr_entity_category = EntityCategory.DIAGNOSTIC
 
@@ -121,7 +120,24 @@ class InfinitudeConnectivityBinarySensorEntity(InfinitudeEntity, BinarySensorEnt
         """The connectivity sensor itself is always available."""
         return True
 
+
+class InfinitudeConnectivityBinarySensorEntity(_InfinitudeConnectivityBase):
+    """Whether the integration can reach the Infinitude server."""
+
+    _attr_name = "Infinitude connectivity"
+
     @property
     def is_on(self) -> bool:
-        """True while HA reached Infinitude and the thermostat is reporting."""
+        """True while the last fetch from Infinitude succeeded."""
+        return self.coordinator.last_update_success
+
+
+class InfinitudeThermostatConnectivityBinarySensorEntity(_InfinitudeConnectivityBase):
+    """Whether the HVAC system is reporting to Infinitude."""
+
+    _attr_name = "Thermostat connectivity"
+
+    @property
+    def is_on(self) -> bool:
+        """True when we have a fresh fetch and the thermostat is reporting."""
         return self.coordinator.last_update_success and self.system.connected

--- a/tests/ha/test_binary_sensor.py
+++ b/tests/ha/test_binary_sensor.py
@@ -1,60 +1,61 @@
-"""Layer 2 — connectivity binary sensor."""
+"""Layer 2 — connectivity binary sensors."""
 
 from __future__ import annotations
 
 from custom_components.infinitude_beyond.const import DOMAIN
 
 
-def _connectivity_state(hass):
+def _state(hass, name_suffix):
     for state in hass.states.async_all("binary_sensor"):
-        if state.attributes.get("device_class") == "connectivity":
+        if state.attributes.get("friendly_name", "").endswith(name_suffix):
             return state
     return None
 
 
-async def test_connectivity_sensor_tracks_coordinator_without_going_unavailable(
-    hass, mock_infinitude, config_entry
-):
+async def _setup(hass, config_entry):
     config_entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
+    return hass.data[DOMAIN][config_entry.entry_id]
 
-    conn = _connectivity_state(hass)
-    assert conn is not None, "expected a connectivity binary sensor"
-    assert conn.state == "on"  # a successful setup means connected
 
-    # A failed fetch must flip it to 'off' (disconnected) -- not 'unavailable',
-    # which is what a plain coordinator entity would do and would make it useless.
-    coordinator = hass.data[DOMAIN][config_entry.entry_id]
+async def test_infinitude_connectivity_tracks_reachability(
+    hass, mock_infinitude, config_entry
+):
+    coordinator = await _setup(hass, config_entry)
+    inf = _state(hass, "Infinitude connectivity")
+    assert inf is not None and inf.state == "on"
+
+    # Flips to disconnected without going unavailable, and recovers.
     coordinator.last_update_success = False
     coordinator.async_update_listeners()
     await hass.async_block_till_done()
+    assert hass.states.get(inf.entity_id).state == "off"
 
-    conn = hass.states.get(conn.entity_id)
-    assert conn.state == "off"
-
-    # And back on when the connection recovers.
     coordinator.last_update_success = True
     coordinator.async_update_listeners()
     await hass.async_block_till_done()
+    assert hass.states.get(inf.entity_id).state == "on"
 
-    assert hass.states.get(conn.entity_id).state == "on"
 
-
-async def test_connectivity_off_when_thermostat_not_reporting(
+async def test_thermostat_connectivity_reflects_reporting(
     hass, mock_infinitude, config_entry
 ):
-    # Infinitude is reachable but the thermostat isn't reporting (empty status).
-    config_entry.add_to_hass(hass)
-    assert await hass.config_entries.async_setup(config_entry.entry_id)
-    await hass.async_block_till_done()
+    coordinator = await _setup(hass, config_entry)
+    tstat = _state(hass, "Thermostat connectivity")
+    inf = _state(hass, "Infinitude connectivity")
+    assert tstat is not None and tstat.state == "on"
 
-    conn = _connectivity_state(hass)
-    assert conn.state == "on"
-
-    coordinator = hass.data[DOMAIN][config_entry.entry_id]
-    coordinator.infinitude._status = None  # thermostat not connected to Infinitude
+    # Thermostat stops reporting while Infinitude stays reachable: only the
+    # thermostat sensor drops.
+    coordinator.infinitude._status = None
     coordinator.async_update_listeners()
     await hass.async_block_till_done()
+    assert hass.states.get(tstat.entity_id).state == "off"
+    assert hass.states.get(inf.entity_id).state == "on"
 
-    assert hass.states.get(conn.entity_id).state == "off"
+    # If HA can't reach Infinitude, we can't confirm the thermostat -> off.
+    coordinator.last_update_success = False
+    coordinator.async_update_listeners()
+    await hass.async_block_till_done()
+    assert hass.states.get(tstat.entity_id).state == "off"


### PR DESCRIPTION
The single connectivity sensor couldn't tell you *which* link was down. Splits it into two:

- **Infinitude connectivity** — the integration ↔ Infinitude server (`last_update_success`). This is #29's original meaning.
- **Thermostat connectivity** — the HVAC system ↔ Infinitude (`last_update_success and system.connected`). Off when the thermostat isn't reporting, or when HA can't reach Infinitude to tell.

So a thermostat that drops off Infinitude now shows Thermostat=off while Infinitude stays on, pinpointing the break. Replaces the combined sensor from #68 (unreleased, so the old `Connectivity` entity just orphans — deletable).