### PR TITLE
Write config via the full-systems save, not /api/config

### DIFF
--- a/custom_components/infinitude_beyond/infinitude/api.py
+++ b/custom_components/infinitude_beyond/infinitude/api.py
@@ -56,6 +56,14 @@ def _opstat_slug(value) -> str | None:
     return _OPSTAT_SLUGS.get(str(value).strip().lower(), str(value))
 
 
+def _vacation_datetime_str(dt: datetime) -> str:
+    """Format a vacation timestamp the way Infinitude's UI writes it.
+
+    Local wall-clock, minute precision, no offset (e.g. 2026-07-01T10:00).
+    """
+    return dt.strftime("%Y-%m-%dT%H:%M")
+
+
 class Infinitude:
     """Object for interacting with the Infinitude API."""
 
@@ -134,14 +142,55 @@ class Infinitude:
                 stripped = text.strip()
                 if stripped:
                     try:
-                        return json.loads(stripped)
+                        result = json.loads(stripped)
                     except ValueError:
-                        pass
+                        result = None
+                    if result is not None:
+                        if (
+                            isinstance(result, dict)
+                            and result.get("status") == "fail"
+                        ):
+                            _LOGGER.warning(
+                                "Infinitude reported a failed write to %s: %s",
+                                endpoint,
+                                result,
+                            )
+                        return result
                 # Empty or non-JSON body: the request still succeeded.
                 self._warn_non_json_post(endpoint)
                 return None
         except ClientError as e:
             _LOGGER.error(e)
+
+    async def _post_json(self, endpoint: str, payload: dict) -> None:
+        """POST a JSON body (used for saving the full systems document)."""
+        url = f"{self.url}{endpoint}"
+        try:
+            _LOGGER.debug("POST(json) %s with %s", url, payload)
+            async with self._session.post(url, json=payload) as resp:
+                resp.raise_for_status()
+        except ClientError as e:
+            _LOGGER.error("POST %s failed: %s", url, e)
+            raise ConnectionError from e
+
+    async def modify_config(self, changes: dict) -> None:
+        """Change system config fields the way the Infinitude UI does.
+
+        Field-level POSTs to /api/config are rejected by current Infinitude
+        (they return {"status":"fail"}). The UI saves by posting the whole
+        systems document to /systems/infinitude, so mirror that: pull the doc,
+        set the fields on its config, post it back.
+        """
+        doc = await self._get("/systems.json")
+        try:
+            system = doc["system"][0]
+            config = system["config"][0]
+        except (KeyError, IndexError, TypeError) as err:
+            raise ConnectionError("Unexpected systems document") from err
+        for key, value in changes.items():
+            config[key] = [value]
+        await self._post_json("/systems/infinitude", {"system": [system]})
+        await self.update()
 
     def _warn_non_json_post(self, endpoint: str) -> None:
         """Log once that Infinitude sent an empty or non-JSON POST response."""
@@ -473,10 +522,7 @@ class InfinitudeSystem:
 
     async def set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set the HVAC mode."""
-
-        endpoint = "/api/config"
-        data = {"mode": f"{hvac_mode.value}"}
-        await self._infinitude._post(endpoint, data)
+        await self._infinitude.modify_config({"mode": hvac_mode.value})
 
     @property
     def filter_level(self) -> int | None:
@@ -622,9 +668,9 @@ class InfinitudeSystem:
 
     async def set_heat_source(self, heatsource: HeatSource) -> None:
         """Set the heat source for a dual-fuel system."""
-        data = {"heatsource": _HEAT_SOURCE_TO_CONFIG[heatsource]}
-        await self._infinitude._post("/api/config", data)
-        await self._infinitude.update()
+        await self._infinitude.modify_config(
+            {"heatsource": _HEAT_SOURCE_TO_CONFIG[heatsource]}
+        )
 
     @property
     def energy(self) -> dict | None:
@@ -638,12 +684,16 @@ class InfinitudeSystem:
         """Parse a vacation window timestamp, tolerating single-digit fields."""
         if not isinstance(value, str):
             return None
-        matches = match(r"^(\d{4})-(\d{1,2})-(\d{1,2})T(\d{2}):(\d{2}):(\d{2})", value)
+        matches = match(
+            r"^(\d{4})-(\d{1,2})-(\d{1,2})T(\d{2}):(\d{2})(?::(\d{2}))?", value
+        )
         if not matches:
             return None
+        year, month, day, hour, minute = (int(g) for g in matches.groups()[:5])
+        second = int(matches.group(6) or 0)
         try:
             return datetime(
-                *(int(g) for g in matches.groups()), tzinfo=self.local_timezone
+                year, month, day, hour, minute, second, tzinfo=self.local_timezone
             )
         except ValueError:
             return None
@@ -718,44 +768,42 @@ class InfinitudeSystem:
         """Write vacation config in a single request.
 
         When enabling without an explicit window (or with a stale/past one),
-        default to now .. now+7 days.
+        default to the next quarter hour .. seven days later.
         """
-        # Write local wall-clock: reads ignore the stored offset and apply the
-        # system timezone, so the written value must be in that same frame.
+        # Write local wall-clock: reads apply the system timezone, so the
+        # written value must be in that same frame.
         tz = self.local_timezone
         if start is not None:
             start = start.replace(tzinfo=tz) if start.tzinfo is None else start.astimezone(tz)
         if end is not None:
             end = end.replace(tzinfo=tz) if end.tzinfo is None else end.astimezone(tz)
 
-        data: dict = {}
+        changes: dict = {}
         if enabled is not None:
-            data["vacat"] = "on" if enabled else "off"
+            changes["vacat"] = "on" if enabled else "off"
         if start is not None:
-            data["vacstart"] = start.replace(microsecond=0).isoformat()
+            changes["vacstart"] = _vacation_datetime_str(start)
         if end is not None:
-            data["vacend"] = end.replace(microsecond=0).isoformat()
+            changes["vacend"] = _vacation_datetime_str(end)
         if heat is not None:
-            data["vacmint"] = str(float(heat))
+            changes["vacmint"] = str(float(heat))
         if cool is not None:
-            data["vacmaxt"] = str(float(cool))
+            changes["vacmaxt"] = str(float(cool))
         if fan is not None:
-            data["vacfan"] = fan.value
+            changes["vacfan"] = fan.value
 
-        if data.get("vacat") == "on" and start is None and end is None:
+        if changes.get("vacat") == "on" and start is None and end is None:
             now = self.local_time
             cur_start, cur_end = self.vacation_start, self.vacation_end
             if not cur_start or not cur_end or (now and cur_end <= now):
-                base = (now or datetime.now(tz=self.local_timezone)).replace(
-                    minute=0, second=0, microsecond=0
-                )
-                data["vacstart"] = base.isoformat()
-                data["vacend"] = (base + timedelta(days=7)).isoformat()
+                base = (now or datetime.now(tz=tz)).replace(second=0, microsecond=0)
+                base += timedelta(minutes=(15 - base.minute % 15) % 15 or 15)
+                changes["vacstart"] = _vacation_datetime_str(base)
+                changes["vacend"] = _vacation_datetime_str(base + timedelta(days=7))
 
-        if not data:
+        if not changes:
             return
-        await self._infinitude._post("/api/config", data)
-        await self._infinitude.update()
+        await self._infinitude.modify_config(changes)
 
 
 class InfinitudeZone:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -87,6 +87,16 @@ def _build_app(payloads: dict, posts: list) -> web.Application:
         await record(request)
         return web.json_response({})
 
+    async def systems(_):
+        # The full systems document, as /systems.json serves it.
+        cfg = payloads["config"].get("data", payloads["config"])
+        return web.json_response({"system": [{"config": [cfg]}]})
+
+    async def post_systems(request):
+        # Config saves post the whole doc here as JSON.
+        posts.append({"path": request.path, "json": await request.json()})
+        return web.Response(text="")
+
     async def fail(_):
         # A failing GET, for the connection-error path (issue #20).
         return web.Response(status=500)
@@ -96,9 +106,11 @@ def _build_app(payloads: dict, posts: list) -> web.Application:
     app.router.add_get("/api/config/", config)
     app.router.add_get("/energy.json", energy)
     app.router.add_get("/profile.json", profile)
+    app.router.add_get("/systems.json", systems)
     app.router.add_get("/api/fail", fail)
     app.router.add_post("/api/config", post_config)
     app.router.add_post("/api/empty-test", post_empty)
+    app.router.add_post("/systems/infinitude", post_systems)
     app.router.add_post("/api/{zone}/activity/{activity}", post_json)
     app.router.add_post("/api/{zone}/hold", post_json)
     return app

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -13,6 +13,7 @@ Tests are grouped into:
 from __future__ import annotations
 
 import logging
+import re
 from datetime import timedelta
 
 import infinitude.api as api_module
@@ -140,9 +141,7 @@ async def test_properties_tolerate_missing_payloads(infinitude):
 
 async def test_set_heat_source_posts_config(infinitude):
     await infinitude.system.set_heat_source(HeatSource.HEATPUMP)
-    posts = [p for p in infinitude.posts if p["path"] == "/api/config"]
-    assert posts, "expected a POST to /api/config"
-    assert posts[-1]["data"] == {"heatsource": "odu only"}
+    assert _last_config_post(infinitude)["heatsource"] == ["odu only"]
 
 
 async def test_activity_current_recognizes_vacation(infinitude):
@@ -191,34 +190,58 @@ async def test_vacation_state_active_via_zone_beats_stale_window(infinitude):
 
 
 def _last_config_post(infinitude):
-    return [p for p in infinitude.posts if p["path"] == "/api/config"][-1]["data"]
+    """Config the integration posted via the full-document save."""
+    posts = [p for p in infinitude.posts if p["path"] == "/systems/infinitude"]
+    return posts[-1]["json"]["system"][0]["config"][0]
 
 
-async def test_set_vacation_enable_defaults_stale_window(infinitude):
+def _capture_changes(infinitude, monkeypatch):
+    """Capture the changes dict passed to modify_config."""
+    captured: dict = {}
+
+    async def fake(changes):
+        captured.update(changes)
+
+    monkeypatch.setattr(infinitude, "modify_config", fake)
+    return captured
+
+
+async def test_modify_config_posts_full_systems_document(infinitude):
+    # The field change is applied onto the whole systems doc and posted back.
+    await infinitude.modify_config({"mode": "cool"})
+    assert _last_config_post(infinitude)["mode"] == ["cool"]
+
+
+async def test_set_hvac_mode_writes_config(infinitude):
+    await infinitude.system.set_hvac_mode(HVACMode.COOL)
+    assert _last_config_post(infinitude)["mode"] == ["cool"]
+
+
+async def test_set_vacation_enable_defaults_stale_window(infinitude, monkeypatch):
     # Stale placeholder window -> enabling installs a fresh one.
     infinitude._config["vacstart"] = "2012-01-1T21:00:00-00:00"
     infinitude._config["vacend"] = "2013-01-1T21:00:00-00:00"
+    changes = _capture_changes(infinitude, monkeypatch)
     await infinitude.system.set_vacation(enabled=True)
-    post = _last_config_post(infinitude)
-    assert post["vacat"] == "on"
-    assert "vacstart" in post and "vacend" in post
+    assert changes["vacat"] == "on"
+    # Short write format: no seconds, no offset.
+    assert re.fullmatch(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}", changes["vacstart"])
+    assert "vacend" in changes
 
 
-async def test_set_vacation_keeps_valid_future_window(infinitude):
+async def test_set_vacation_keeps_valid_future_window(infinitude, monkeypatch):
     # A valid future window (fixture clock is 2024-01-15) is left untouched.
     infinitude._config["vacstart"] = "2024-06-01T00:00:00-05:00"
     infinitude._config["vacend"] = "2024-07-01T00:00:00-05:00"
+    changes = _capture_changes(infinitude, monkeypatch)
     await infinitude.system.set_vacation(enabled=True)
-    assert _last_config_post(infinitude) == {"vacat": "on"}
+    assert changes == {"vacat": "on"}
 
 
-async def test_set_vacation_writes_setpoints_and_fan(infinitude):
+async def test_set_vacation_writes_setpoints_and_fan(infinitude, monkeypatch):
+    changes = _capture_changes(infinitude, monkeypatch)
     await infinitude.system.set_vacation(heat=60, cool=80, fan=FanMode.LOW)
-    assert _last_config_post(infinitude) == {
-        "vacmint": "60.0",
-        "vacmaxt": "80.0",
-        "vacfan": "low",
-    }
+    assert changes == {"vacmint": "60.0", "vacmaxt": "80.0", "vacfan": "low"}
 
 
 async def test_vacation_setpoints_parse_float_strings(infinitude):
@@ -228,9 +251,10 @@ async def test_vacation_setpoints_parse_float_strings(infinitude):
     assert infinitude.system.vacation_cool == 90.0
 
 
-async def test_set_vacation_disable(infinitude):
+async def test_set_vacation_disable(infinitude, monkeypatch):
+    changes = _capture_changes(infinitude, monkeypatch)
     await infinitude.system.set_vacation(enabled=False)
-    assert _last_config_post(infinitude) == {"vacat": "off"}
+    assert changes == {"vacat": "off"}
 
 
 async def test_zone_temperatures(infinitude):


### PR DESCRIPTION
Vacation (and any config) writes were silently failing: posting fields to `/api/config` hits Infinitude's generic path handler, which returns `200 OK` with `{"status":"fail"}`. `_post` never inspected the body, so the write looked like it succeeded while doing nothing.

Infinitude's own web UI never uses that path — it saves by posting the whole systems document to `POST /systems/infinitude`. This mirrors that:

- New `modify_config` helper: GET `/systems.json`, set the fields on `config`, POST `{system:[doc]}` back.
- Route `set_hvac_mode`, `set_heat_source`, and `set_vacation` through it.
- Vacation timestamps now use the UI's `YYYY-MM-DDTHH:MM` format (no seconds/offset); the read parser accepts seconds present or absent.
- `_post` now logs a `status:fail` body so a rejected write can't fail silently again.

**Audit of write paths:** only the three system-config writes hit the broken `/api/config` path. The zone writes (`set_temperature`, `set_fan_mode`, `set_hold_mode`) use the dedicated `/api/{zone}/activity` and `/api/{zone}/hold` handlers and were working — left unchanged.

Needs a final on-hardware confirm that the vacation write now takes effect.