### PR TITLE
Fix target_temperature crash in Auto mode (#72)

### DIFF
--- a/custom_components/infinitude_beyond/climate.py
+++ b/custom_components/infinitude_beyond/climate.py
@@ -162,12 +162,12 @@ class InfinitudeClimate(InfinitudeEntity, ClimateEntity):
                 InfHVACAction.ACTIVE_HEAT,
                 InfHVACAction.PREP_HEAT,
             ]:
-                return self.setpoint_heat
+                return self.zone.temperature_heat
             elif self.zone.hvac_action in [
                 InfHVACAction.ACTIVE_COOL,
                 InfHVACAction.PREP_COOL,
             ]:
-                return self.setpoint_cool
+                return self.zone.temperature_cool
             else:
                 return self.zone.temperature_current
 

--- a/tests/ha/test_climate.py
+++ b/tests/ha/test_climate.py
@@ -23,6 +23,8 @@ from custom_components.infinitude_beyond.infinitude.const import (
     FanMode,
     HeatSource,
     HoldMode,
+    HVACAction as InfHVACAction,
+    HVACMode as InfHVACMode,
 )
 from homeassistant.components.climate import HVACMode
 
@@ -87,6 +89,24 @@ async def test_set_heat_source_maps_slug_to_enum():
     entity.system.set_heat_source = AsyncMock()
     await entity.async_set_heat_source("heat_pump")
     entity.system.set_heat_source.assert_awaited_once_with(HeatSource.HEATPUMP)
+
+
+@pytest.mark.parametrize(
+    "action,attr,value",
+    [
+        (InfHVACAction.ACTIVE_COOL, "temperature_cool", 75.0),
+        (InfHVACAction.ACTIVE_HEAT, "temperature_heat", 68.0),
+    ],
+    ids=["cool", "heat"],
+)
+def test_target_temperature_in_auto_uses_zone_setpoint(action, attr, value):
+    # #72: the Auto branch referenced a nonexistent self.setpoint_* and crashed
+    # whenever a zone in Auto was actively heating/cooling.
+    entity, zone = _make_entity()
+    zone.hvac_mode = InfHVACMode.AUTO
+    zone.hvac_action = action
+    setattr(zone, attr, value)
+    assert entity.target_temperature == value
 
 
 async def test_preset_mode_reports_vacation():


### PR DESCRIPTION
A zone in Auto mode that's actively heating or cooling threw `AttributeError: 'InfinitudeClimate' object has no attribute 'setpoint_cool'` on every update cycle (state_attributes reads target_temperature each write).

The Auto branch of `target_temperature` returned `self.setpoint_heat` / `self.setpoint_cool` — names that never existed on the entity. The underlying API properties were removed in the "API cleanup" commit the day before the climate entity was first written, and the Heat/Cool branches already use `self.zone.temperature_heat` / `temperature_cool`. So this branch has been dead since day one; it only fires in Auto + active heat/cool, which is why it went unnoticed for ~2.5 years.

Fix: point the two Auto-branch lines at the same zone setpoints. Adds a regression test for Auto + active heat/cool (fails on the old code, passes now).

Closes #72.