### PR TITLE
Show heat/cool setpoint range on the thermostat card in Auto mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ env/
 .mypy_cache/
 .coverage
 htmlcov/
+uv.lock
 
 # Home Assistant dev runtime (created by scripts/develop)
 /config/

--- a/custom_components/infinitude_beyond/climate.py
+++ b/custom_components/infinitude_beyond/climate.py
@@ -157,19 +157,10 @@ class InfinitudeClimate(InfinitudeEntity, ClimateEntity):
     @property
     def target_temperature(self) -> float:
         """Return the target temperature."""
+        # In Auto (HEAT_COOL), HA renders a range from target_temperature_high/low;
+        # returning a single value here suppresses the range on the thermostat card.
         if self.zone.hvac_mode == InfHVACMode.AUTO:
-            if self.zone.hvac_action in [
-                InfHVACAction.ACTIVE_HEAT,
-                InfHVACAction.PREP_HEAT,
-            ]:
-                return self.zone.temperature_heat
-            elif self.zone.hvac_action in [
-                InfHVACAction.ACTIVE_COOL,
-                InfHVACAction.PREP_COOL,
-            ]:
-                return self.zone.temperature_cool
-            else:
-                return self.zone.temperature_current
+            return None
 
         if self.zone.hvac_mode == InfHVACMode.HEAT:
             return self.zone.temperature_heat
@@ -182,11 +173,15 @@ class InfinitudeClimate(InfinitudeEntity, ClimateEntity):
     @property
     def target_temperature_high(self) -> float:
         """Return the high target temperature."""
+        if self.zone.hvac_mode != InfHVACMode.AUTO:
+            return None
         return self.zone.temperature_cool
 
     @property
     def target_temperature_low(self) -> float:
         """Return the low target temperature."""
+        if self.zone.hvac_mode != InfHVACMode.AUTO:
+            return None
         return self.zone.temperature_heat
 
     async def async_set_temperature(self, **kwargs):

--- a/custom_components/infinitude_beyond/climate.py
+++ b/custom_components/infinitude_beyond/climate.py
@@ -155,7 +155,7 @@ class InfinitudeClimate(InfinitudeEntity, ClimateEntity):
         return self.zone.temperature_current
 
     @property
-    def target_temperature(self) -> float:
+    def target_temperature(self) -> float | None:
         """Return the target temperature."""
         # In Auto (HEAT_COOL), HA renders a range from target_temperature_high/low;
         # returning a single value here suppresses the range on the thermostat card.
@@ -171,14 +171,14 @@ class InfinitudeClimate(InfinitudeEntity, ClimateEntity):
         return self.zone.temperature_current
 
     @property
-    def target_temperature_high(self) -> float:
+    def target_temperature_high(self) -> float | None:
         """Return the high target temperature."""
         if self.zone.hvac_mode != InfHVACMode.AUTO:
             return None
         return self.zone.temperature_cool
 
     @property
-    def target_temperature_low(self) -> float:
+    def target_temperature_low(self) -> float | None:
         """Return the low target temperature."""
         if self.zone.hvac_mode != InfHVACMode.AUTO:
             return None

--- a/custom_components/infinitude_beyond/infinitude/api.py
+++ b/custom_components/infinitude_beyond/infinitude/api.py
@@ -1114,9 +1114,11 @@ class InfinitudeZone:
     @property
     def activity_next(self) -> Activity | None:
         """Next scheduled activity."""
+        if not self._activity_next:
+            return None
         activity = next((a for a in Activity if a.value == self._activity_next), None)
         if activity is None:
-            _LOGGER.warning("'%s' is an unknown Next Activity", self._activity_next)
+            _LOGGER.debug("'%s' is an unknown Next Activity", self._activity_next)
         return activity
 
     @property

--- a/custom_components/infinitude_beyond/sensor.py
+++ b/custom_components/infinitude_beyond/sensor.py
@@ -201,7 +201,9 @@ ZONE_SENSORS: tuple[InfinitudeSensorDescription, ...] = (
     InfinitudeSensorDescription(
         key="hold_state",
         name="Hold state",
-        value_fn=lambda entity: entity.zone.hold_state.value,
+        value_fn=lambda entity: (
+            entity.zone.hold_state.value if entity.zone.hold_state else None
+        ),
     ),
     InfinitudeSensorDescription(
         key="hold_until",

--- a/tests/ha/test_climate.py
+++ b/tests/ha/test_climate.py
@@ -91,22 +91,37 @@ async def test_set_heat_source_maps_slug_to_enum():
     entity.system.set_heat_source.assert_awaited_once_with(HeatSource.HEATPUMP)
 
 
-@pytest.mark.parametrize(
-    "action,attr,value",
-    [
-        (InfHVACAction.ACTIVE_COOL, "temperature_cool", 75.0),
-        (InfHVACAction.ACTIVE_HEAT, "temperature_heat", 68.0),
-    ],
-    ids=["cool", "heat"],
-)
-def test_target_temperature_in_auto_uses_zone_setpoint(action, attr, value):
-    # #72: the Auto branch referenced a nonexistent self.setpoint_* and crashed
-    # whenever a zone in Auto was actively heating/cooling.
+def test_target_temperature_is_none_in_auto():
+    # In Auto (HEAT_COOL), HA renders a low/high range on the thermostat card.
+    # target_temperature must be None so the card picks up the range instead of
+    # falling back to a single-setpoint display.
     entity, zone = _make_entity()
     zone.hvac_mode = InfHVACMode.AUTO
-    zone.hvac_action = action
+    zone.hvac_action = InfHVACAction.ACTIVE_COOL
+    zone.temperature_heat = 68.0
+    zone.temperature_cool = 75.0
+    assert entity.target_temperature is None
+    assert entity.target_temperature_low == 68.0
+    assert entity.target_temperature_high == 75.0
+
+
+@pytest.mark.parametrize(
+    "mode,attr,value",
+    [
+        (InfHVACMode.HEAT, "temperature_heat", 68.0),
+        (InfHVACMode.COOL, "temperature_cool", 75.0),
+    ],
+    ids=["heat", "cool"],
+)
+def test_target_temperature_single_mode_returns_setpoint(mode, attr, value):
+    # Single-setpoint modes populate target_temperature and leave high/low unset
+    # so the card renders one dot, not a range.
+    entity, zone = _make_entity()
+    zone.hvac_mode = mode
     setattr(zone, attr, value)
     assert entity.target_temperature == value
+    assert entity.target_temperature_low is None
+    assert entity.target_temperature_high is None
 
 
 async def test_preset_mode_reports_vacation():

--- a/tests/ha/test_sensor.py
+++ b/tests/ha/test_sensor.py
@@ -17,6 +17,20 @@ def test_occupancy_sensor_gated_on_value():
     assert desc.exists_fn(entity) is True
 
 
+def test_hold_state_sensor_tolerates_missing_hold():
+    # The 'hold' field is absent from the config document during some mode
+    # transitions; before the guard, the state write crashed with
+    # AttributeError: 'NoneType' object has no attribute 'value'.
+    from custom_components.infinitude_beyond.infinitude.const import HoldState
+
+    desc = next(d for d in ZONE_SENSORS if d.key == "hold_state")
+    entity = MagicMock()
+    entity.zone.hold_state = None
+    assert desc.value_fn(entity) is None
+    entity.zone.hold_state = HoldState.ON
+    assert desc.value_fn(entity) == "on"
+
+
 async def test_modulation_sensors_only_register_when_reported(
     hass, mock_infinitude, config_entry
 ):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -286,6 +286,19 @@ async def test_hold_off_by_default(infinitude):
     assert zone.hold_mode is HoldMode.OFF
 
 
+async def test_activity_next_missing_is_quiet(infinitude, caplog):
+    # A config with no upcoming activity would previously warn "'None' is an
+    # unknown Next Activity" on every coordinator refresh. Return None quietly
+    # to match activity_current / activity_scheduled.
+    zone = infinitude.zones["1"]
+    zone._activity_next = None
+    with caplog.at_level(logging.WARNING, logger="infinitude.api"):
+        assert zone.activity_next is None
+    assert not any(
+        "unknown Next Activity" in rec.message for rec in caplog.records
+    )
+
+
 async def test_set_temperature_posts_manual_activity(infinitude):
     await infinitude.zones["1"].set_temperature(temperature=72)
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,8 +1,0 @@
-version = 1
-revision = 3
-requires-python = ">=3.14"
-
-[[package]]
-name = "infinitude-beyond"
-version = "0.0.0"
-source = { virtual = "." }

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,8 @@
+version = 1
+revision = 3
+requires-python = ">=3.14"
+
+[[package]]
+name = "infinitude-beyond"
+version = "0.0.0"
+source = { virtual = "." }


### PR DESCRIPTION
## Range display on the thermostat card in Auto mode

In Auto (HEAT_COOL), Home Assistant's thermostat card is supposed to render a dual-setpoint arc — a low dot for the heat setpoint and a high dot for the cool setpoint — the same way ecobee, nest, and other range-capable integrations display. Infinitude Beyond was collapsing it to a single value, so users in Auto saw one dot and one number instead of the range they actually control.

The card picks between single-setpoint and range display based on which climate properties are populated. When `target_temperature` is set alongside `target_temperature_high`/`target_temperature_low`, the card falls back to the single-value layout. This integration was returning a value for `target_temperature` in every mode, including Auto (PR #72 fixed a crash in that branch but preserved the always-return-a-value shape), which suppressed the range.

Change:
- `target_temperature` returns `None` in Auto so the card uses the low/high pair.
- `target_temperature_high` / `target_temperature_low` return `None` outside Auto so single-setpoint modes render one dot cleanly.

Notes:
- Any automation reading `state.attributes.temperature` on an Auto-mode zone will now get `None` instead of the current-side setpoint. That matches the HA climate contract and how other range-capable integrations behave; automations wanting a specific side should read `target_temp_low` or `target_temp_high`.
- The PR #72 test (`test_target_temperature_in_auto_uses_zone_setpoint`) asserted the old behavior and is replaced by `test_target_temperature_is_none_in_auto` plus `test_target_temperature_single_mode_returns_setpoint[heat|cool]`.

Before:
<img width="496" height="496" alt="image" src="https://github.com/user-attachments/assets/e472c52e-1add-4ca1-ba3b-37209fa5ebdb" />

After:
<img width="323" height="480" alt="image" src="https://github.com/user-attachments/assets/ce24e55b-2666-4799-85de-367f993f04ee" />

## Related: null-safety around missing hold / next-activity state

Reproduced while switching a zone to Heat/Cool: the Infinitude backend briefly returns a config document without a `hold` field during the transition, which crashed the `hold_state` sensor's state write and spammed the log with a spurious "unknown Next Activity" warning on every coordinator refresh. Both are pre-existing and independent of the range fix, but they surface in the same Auto-mode flow so they're bundled here.

- `sensor.py` — the `hold_state` sensor now returns `None` when the API's `zone.hold_state` is `None`, matching the guard already present on `hold_activity` directly above it. Fixes `AttributeError: 'NoneType' object has no attribute 'value'` at `sensor.py:204`.
- `infinitude/api.py` — `activity_next` short-circuits and returns `None` when the underlying `_activity_next` is falsy, and drops the "unknown" log from `warning` to `debug` to match `activity_current` / `activity_scheduled`. Stops the "'None' is an unknown Next Activity" warning that fired on every refresh when no next activity was scheduled.

New tests: `test_hold_state_sensor_tolerates_missing_hold` and `test_activity_next_missing_is_quiet`.